### PR TITLE
feat: 홈(강좌 목록) 페이지 및 강사 권한 요청 모달 구현

### DIFF
--- a/src/domains/auth/hooks/useAuthState.js
+++ b/src/domains/auth/hooks/useAuthState.js
@@ -1,5 +1,7 @@
 import { subscribeAuthState } from '@/domains/auth/services/authService';
-import { createUserProfile, getUserProfile } from '@/domains/user/services/UserService';
+import { createUserProfile } from '@/domains/user/services/userService';
+import { db } from '@/shared/lib/firebase/firestore';
+import { doc, getDoc, onSnapshot } from 'firebase/firestore';
 import { useEffect, useState } from 'react';
 
 export const useAuthState = () => {
@@ -7,51 +9,50 @@ export const useAuthState = () => {
   const [initialized, setInitialized] = useState(false);
 
   useEffect(() => {
-    const unsubscribe = subscribeAuthState(async (authUser) => {
-      try {
-        // 로그아웃 상태
-        if (!authUser) {
-          setUser(null);
-          setInitialized(true);
-          return;
-        }
+    let unsubscribeUserDoc = null;
 
-        // Firestore 유저 문서 읽기
-        let userDoc = await getUserProfile(authUser.uid);
-
-        // Firestore 문서가 없으면 새로 생성 (최초 회원)
-        if (!userDoc) {
-          userDoc = await createUserProfile(authUser); // 네가 만든 함수 그대로 사용
-        }
-
-        // Timestamp 안전 변환 (없으면 null)
-        const createdAt =
-          userDoc.createdAt?.toDate?.().toISOString?.() ?? userDoc.createdAt ?? null;
-        const updatedAt =
-          userDoc.updatedAt?.toDate?.().toISOString?.() ?? userDoc.updatedAt ?? null;
-
-        // 최종 user 객체
-        setUser({
-          id: userDoc.id,
-          email: authUser.email,
-          name: userDoc.name ?? authUser.displayName ?? '',
-          roles: userDoc.roles ?? ['USER'],
-          cart: userDoc.cart ?? [],
-          enrolledCourseIds: userDoc.enrolledCourseIds ?? [],
-          createdCourses: userDoc.createdCourses ?? [],
-          avatarUrl: userDoc.avatarUrl ?? authUser.photoURL ?? null,
-          createdAt,
-          updatedAt,
-        });
-      } catch (error) {
-        console.error('useAuthState 오류', error);
+    const unsubscribeAuth = subscribeAuthState(async (authUser) => {
+      // 로그아웃
+      if (!authUser) {
         setUser(null);
-      } finally {
         setInitialized(true);
+        if (unsubscribeUserDoc) unsubscribeUserDoc();
+        return;
       }
+
+      const ref = doc(db, 'users', authUser.uid);
+      let userDocSnap = await getDoc(ref);
+      if (!userDocSnap.exists()) {
+        await createUserProfile(authUser);
+        userDocSnap = await getDoc(ref);
+      }
+
+      if (unsubscribeUserDoc) unsubscribeUserDoc();
+      unsubscribeUserDoc = onSnapshot(ref, (snap) => {
+        if (!snap.exists()) return;
+        const data = snap.data();
+        setUser({
+          id: authUser.uid,
+          email: authUser.email,
+          name: data.name ?? authUser.displayName ?? '',
+          roles: data.roles ?? ['USER'],
+          cart: data.cart ?? [],
+          enrolledCourses: data.enrolledCourses ?? [],
+          createdCourses: data.createdCourses ?? [],
+          avatarUrl: data.avatarUrl ?? authUser.photoURL ?? null,
+          createdAt: data.createdAt?.toDate?.().toISOString?.() ?? data.createdAt ?? null,
+          updatedAt: data.updatedAt?.toDate?.().toISOString?.() ?? data.updatedAt ?? null,
+        });
+
+        // user가 세팅된 이후에 초기화 완료
+        setInitialized(true);
+      });
     });
 
-    return () => unsubscribe();
+    return () => {
+      unsubscribeAuth();
+      if (unsubscribeUserDoc) unsubscribeUserDoc();
+    };
   }, []);
 
   return { user, loading: !initialized, initialized };

--- a/src/domains/course/components/CourseCard.jsx
+++ b/src/domains/course/components/CourseCard.jsx
@@ -2,11 +2,6 @@ import { Link } from 'react-router';
 import styles from './CourseCard.module.css';
 
 export function CourseCard({ course }) {
-  // 카테고리 문자열로 변환 (배열 → " > " 구분자)
-  const categoryPath = Array.isArray(course.category)
-    ? course.category.join(' > ')
-    : course.category;
-
   return (
     <Link
       to={`/courses/${course.id}`}
@@ -23,13 +18,13 @@ export function CourseCard({ course }) {
       </div>
 
       <div className={styles['course-card__body']}>
-        <h3 className={styles['course-card__title']}>{course.title}</h3>
+        <div>
+          <h3 className={styles['course-card__title']}>{course.title}</h3>
+        </div>
 
-        {/* 강사명 + 카테고리 경로 */}
-        <p className={styles['course-card__meta']}>
-          <span className={styles['course-card__instructor']}>{course.instructorName}</span>
-          {categoryPath && <span className={styles['course-card__category']}>{categoryPath}</span>}
-        </p>
+        <div className={`${styles['course-card__meta']} ${styles['course-card__instructor']}`}>
+          {course.instructorName}
+        </div>
 
         {course.summary && <p className={styles['course-card__summary']}>{course.summary}</p>}
 
@@ -50,11 +45,9 @@ export function CourseCard({ course }) {
           <span className={styles['course-card__price']}>
             {course.isFree ? '무료' : `₩${course.price.toLocaleString()}`}
           </span>
-          {
-            <span className={styles['course-card__students']}>
-              👥 {course.studentCount.toLocaleString()}
-            </span>
-          }
+          {/* <span className={styles['course-card__students']}>
+             {course.studentCount.toLocaleString()}
+          </span> */}
         </div>
       </div>
     </Link>

--- a/src/domains/course/components/CourseCard.jsx
+++ b/src/domains/course/components/CourseCard.jsx
@@ -1,37 +1,62 @@
-import React from "react";
-import styles from "./CourseCard.module.css";
+import { Link } from 'react-router';
+import styles from './CourseCard.module.css';
 
-export function CourseCard() {
+export function CourseCard({ course }) {
+  // 카테고리 문자열로 변환 (배열 → " > " 구분자)
+  const categoryPath = Array.isArray(course.category)
+    ? course.category.join(' > ')
+    : course.category;
+
   return (
-    <article
-      className={styles["course-card"]}
-      aria-labelledby="course-card-title"
+    <Link
+      to={`/courses/${course.id}`}
+      className={styles['course-card']}
+      aria-label={`${course.title} 상세 보기`}
     >
-      <a
-        href="/courses/placeholder"
-        className={styles["course-card__thumb-link"]}
-      >
+      <div className={styles['course-card__thumb-wrapper']}>
         <img
-          className={styles["course-card__thumb"]}
-          src="https://via.placeholder.com/480x270"
-          alt="React 입문 강좌 썸네일"
+          className={styles['course-card__thumb']}
+          src={course.thumbnail}
+          alt={`${course.title} 썸네일`}
           loading="lazy"
         />
-      </a>
-      <div className={styles["course-card__body"]}>
-        <h3 id="course-card-title" className={styles["course-card__title"]}>
-          <a
-            className={styles["course-card__title-link"]}
-            href="/courses/placeholder"
-          >
-            React 입문
-          </a>
-        </h3>
-        <p className={styles["course-card__meta"]}>강사: 홍길동 • 입문</p>
-        <div className={styles["course-card__foot"]}>
-          <span className={styles["course-card__price"]}>₩49,000</span>
+      </div>
+
+      <div className={styles['course-card__body']}>
+        <h3 className={styles['course-card__title']}>{course.title}</h3>
+
+        {/* 강사명 + 카테고리 경로 */}
+        <p className={styles['course-card__meta']}>
+          <span className={styles['course-card__instructor']}>{course.instructorName}</span>
+          {categoryPath && <span className={styles['course-card__category']}>{categoryPath}</span>}
+        </p>
+
+        {course.summary && <p className={styles['course-card__summary']}>{course.summary}</p>}
+
+        {course.tags?.length > 0 && (
+          <ul className={styles['course-card__tags']}>
+            {course.tags.map((tag) => (
+              <li
+                key={tag}
+                className={`${styles['course-card__tag']} ${styles['course-card__tag--category']}`}
+              >
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )}
+
+        <div className={styles['course-card__foot']}>
+          <span className={styles['course-card__price']}>
+            {course.isFree ? '무료' : `₩${course.price.toLocaleString()}`}
+          </span>
+          {
+            <span className={styles['course-card__students']}>
+              👥 {course.studentCount.toLocaleString()}
+            </span>
+          }
         </div>
       </div>
-    </article>
+    </Link>
   );
 }

--- a/src/domains/course/components/CourseCard.module.css
+++ b/src/domains/course/components/CourseCard.module.css
@@ -6,8 +6,12 @@
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
   overflow: hidden;
+  cursor: pointer;
+  text-decoration: none;
   /* box-shadow: var(--shadow-sm); */
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .course-card:hover,
@@ -54,15 +58,33 @@
 .course-card__title-link:focus-visible {
   color: var(--color-brand-700);
 }
-
 .course-card__meta {
   margin: 0;
+  display: flex;
+  flex-direction: column; /* 강사명 위, 카테고리 아래 */
+  align-items: flex-start;
+  gap: var(--space-2);
   color: var(--color-text-muted);
   font-size: var(--text-sm);
-  display: flex;
-  align-items: center;
-  gap: var(--space-2);
   white-space: normal;
+}
+
+/* 강사명 기본 유지 */
+.course-card__instructor {
+  color: var(--color-text-muted);
+}
+
+/* 카테고리는 한 단계 작게, 더 연한 색 */
+.course-card__category {
+  font-size: var(--text-xs);
+  color: var(--color-text-subtle);
+  letter-spacing: 0.02em;
+}
+
+/* 중간 구분용 '·' 자동 추가 (접근성 영향 X) */
+.course-card__category::before {
+  margin-right: var(--space-1);
+  color: var(--color-text-border);
 }
 
 .course-card__foot {
@@ -87,7 +109,9 @@
   color: var(--color-text);
   font-size: var(--text-sm);
   font-weight: 600;
-  transition: background 0.2s ease, transform 0.2s ease;
+  transition:
+    background 0.2s ease,
+    transform 0.2s ease;
 }
 
 .course-card__cta:hover,
@@ -101,6 +125,54 @@
 
 .course-grid .course-card {
   flex: 1 1 100%;
+}
+
+.course-card__summary {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  line-height: 1.5;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.course-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.course-card__tag {
+  font-size: var(--text-xs);
+  font-weight: 500;
+  border-radius: var(--radius-sm);
+  padding: var(--space-1) var(--space-2);
+  background: var(--color-surface-alt);
+  color: var(--color-text-muted);
+}
+
+.course-card__tag--category {
+  padding: var(--space-1) var(--space-3);
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.16);
+  color: var(--color-brand-700);
+  font-size: var(--text-xs);
+  letter-spacing: 0.04em;
+}
+
+.course-card__tag--level {
+  background: var(--color-accent-bg);
+  color: var(--color-accent-text);
+}
+
+.course-card__students {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
 }
 
 @media (min-width: 768px) {
@@ -118,5 +190,46 @@
 @media (min-width: 768px) {
   .course-card__body {
     padding: var(--space-5);
+  }
+}
+
+.course-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+  padding-block: var(--space-6);
+}
+
+.course-list__toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding-inline: var(--space-2);
+}
+
+.course-list__content {
+  min-width: 0;
+}
+
+.course-list__cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+  justify-content: flex-start;
+  align-items: stretch;
+}
+
+.course-list__cards .course-card {
+  flex: 1 1 100%;
+}
+
+@media (min-width: 768px) {
+  .course-list__cards .course-card {
+    flex: 1 1 calc((100% - var(--space-4)) / 2);
+  }
+}
+
+@media (min-width: 1200px) {
+  .course-list__cards .course-card {
+    flex: 1 1 calc((100% - 3 * var(--space-4)) / 4);
   }
 }

--- a/src/domains/course/pages/CourseListPage.jsx
+++ b/src/domains/course/pages/CourseListPage.jsx
@@ -1,41 +1,43 @@
-import React from "react";
-import styles from "./CourseListPage.module.css";
-import { FilterSidebar } from "@/domains/course/components/FilterSidebar";
-import { SortSelect } from "@/domains/course/components/SortSelect";
-import { CourseCard } from "@/domains/course/components/CourseCard";
-import { SearchBar } from "../components/SearchBar";
+import { CourseCard } from '@/domains/course/components/CourseCard';
+import { getAllCourses } from '@/domains/course/services/courseService';
+import { useEffect, useState } from 'react';
+import styles from './CourseListPage.module.css';
 
 export default function CourseListPage() {
+  const [courses, setCourses] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCourses = async () => {
+      try {
+        const data = await getAllCourses();
+        setCourses(data);
+      } catch (err) {
+        console.error('강좌 목록 불러오기 실패:', err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchCourses();
+  }, []);
+
   return (
-    <main className={`${styles["catalog"]} container`} aria-label="강좌 목록">
-      {/* 툴바 */}
-      <div className={styles["catalog__toolbar"]}>
-        <SearchBar />
-        <SortSelect />
-      </div>
-
-      {/* 본문 2열 */}
-      <div className={styles["catalog__grid"]}>
-        {/* 사이드바 */}
-        <aside className={styles["catalog__sidebar"]}>
-          <FilterSidebar />
-        </aside>
-
-        {/* 콘텐츠 */}
-        <section
-          className={styles["catalog__content"]}
-          aria-label="강좌 카드 목록"
-        >
-          <div
-            className={`${styles["catalog__cards"]} ${styles["course-grid"]}`}
-          >
-            {/* 데모 카드 8개 */}
-            {Array.from({ length: 8 }).map((_, i) => (
-              <CourseCard key={i} />
+    <main className={`${styles['course-list']} container`} aria-label="강좌 목록">
+      {/* 본문 */}
+      <section className={styles['course-list__content']} aria-label="강좌 카드 목록">
+        {loading ? (
+          <p className={styles['course-list__loading']}>불러오는 중...</p>
+        ) : courses.length === 0 ? (
+          <p className={styles['course-list__empty']}>등록된 강좌가 없습니다.</p>
+        ) : (
+          <div className={`${styles['course-list__cards']} ${styles['course-grid']}`}>
+            {courses.map((course) => (
+              <CourseCard key={course.id} course={course} />
             ))}
           </div>
-        </section>
-      </div>
+        )}
+      </section>
     </main>
   );
 }

--- a/src/domains/course/pages/CourseListPage.module.css
+++ b/src/domains/course/pages/CourseListPage.module.css
@@ -1,62 +1,71 @@
-.catalog {
+.course-list {
   display: grid;
   gap: var(--space-5);
   padding-block: var(--space-6);
 }
 
-.catalog__toolbar {
+.course-list__toolbar {
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
   align-items: center;
 }
 
-.catalog__grid {
+.course-list__grid {
   display: grid;
   gap: var(--space-4);
 }
 
-.catalog__sidebar {
+/* 사이드바: 기본 비활성 상태지만 구조만 유지 */
+.course-list__sidebar {
   display: block;
 }
 
-.catalog__content {
+/* 콘텐츠 */
+.course-list__content {
   min-width: 0;
 }
 
 .course-grid {
   display: grid;
-  flex-wrap: wrap;
   gap: var(--space-4);
-  grid-template-columns: 1fr;
+  grid-template-columns: 1fr; /* 기본: 1열 */
 }
 
 @media (min-width: 768px) {
-  .catalog__toolbar {
+  .course-list__toolbar {
     grid-template-columns: minmax(0, 1fr) max-content;
   }
 
-  .catalog__grid {
+  .course-list__grid {
     grid-template-columns: 280px 1fr;
     align-items: start;
   }
 
   .course-grid {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(2, 1fr); /* 태블릿: 2열 */
   }
 }
 
 @media (min-width: 1200px) {
-  .catalog__grid {
+  .course-list__grid {
     grid-template-columns: 250px 1fr;
   }
 
-  .catalog__sidebar {
+  .course-list__sidebar {
     position: sticky;
     top: var(--space-10);
   }
 
   .course-grid {
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, 1fr); /* 데스크탑: 4열 */
   }
+}
+
+.course-list__loading,
+.course-list__empty {
+  text-align: center;
+  color: var(--color-text-muted);
+  font-size: var(--text-md);
+  padding-block: var(--space-8);
 }

--- a/src/domains/course/services/courseService.js
+++ b/src/domains/course/services/courseService.js
@@ -1,0 +1,16 @@
+import { db } from '@/shared/lib/firebase/firestore';
+import { collection, getDocs, orderBy, query } from 'firebase/firestore';
+
+/**
+ * 모든 강좌 목록을 불러옵니다.
+ * @returns {Promise<Array>} 강좌 리스트
+ */
+export const getAllCourses = async () => {
+  const q = query(collection(db, 'courses'), orderBy('createdAt', 'desc'));
+  const snap = await getDocs(q);
+
+  return snap.docs.map((doc) => ({
+    id: doc.id,
+    ...doc.data(),
+  }));
+};

--- a/src/domains/user/components/RoleRequestModal.jsx
+++ b/src/domains/user/components/RoleRequestModal.jsx
@@ -1,46 +1,45 @@
-import { Modal } from '../../../shared/ui/Modal';
+import { updateUserToInstructor } from '@/domains/user/services/userService';
+import { Modal } from '@/shared/ui/Modal';
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
 
-export function RoleRequestModal({ isOpen, onClose }) {
+export function RoleRequestModal({ isOpen, onClose, user }) {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(false);
+
+  const handleConfirm = async () => {
+    try {
+      setLoading(true);
+      // Firestore roles 업데이트 (예: ["USER", "INSTRUCTOR"])
+      await updateUserToInstructor(user.id);
+
+      onClose();
+      navigate('/mypage');
+    } catch (err) {
+      console.error('강사 권한 부여 실패:', err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <header className="modal__header">
         <h2 id="role-request-title" className="modal__title">
-          강사 권한 요청
+          강사가 되시겠습니까?
         </h2>
         <button type="button" className="modal__close" aria-label="닫기" onClick={onClose}>
           ×
         </button>
       </header>
-      <div className="modal__body">
-        <form className="modal__form" aria-label="강사 권한 요청 폼">
-          <div className="modal__field">
-            <label htmlFor="rr-name" className="modal__label">
-              이름
-            </label>
-            <input id="rr-name" type="text" className="modal__input" />
-          </div>
-          <div className="modal__field">
-            <label htmlFor="rr-portfolio" className="modal__label">
-              포트폴리오 URL
-            </label>
-            <input
-              id="rr-portfolio"
-              type="url"
-              className="modal__input"
-              placeholder="https://..."
-            />
-          </div>
-          <div className="modal__field">
-            <label htmlFor="rr-message" className="modal__label">
-              요청 사유
-            </label>
-            <textarea id="rr-message" rows="4" className="modal__textarea" />
-          </div>
-        </form>
+
+      <div className="modal__body" style={{ paddingTop: '8px' }}>
+        <p className="modal__text">강의를 등록하려면 강사 권한이 필요합니다.</p>
       </div>
+
       <footer className="modal__actions">
-        <button type="submit" className="modal__button">
-          요청 보내기
+        <button type="button" className="modal__button" onClick={handleConfirm} disabled={loading}>
+          {loading ? '처리 중...' : '확인'}
         </button>
       </footer>
     </Modal>

--- a/src/domains/user/services/userService.js
+++ b/src/domains/user/services/userService.js
@@ -1,5 +1,5 @@
 import { db } from '@/shared/lib/firebase/firestore';
-import { doc, getDoc, serverTimestamp, setDoc } from 'firebase/firestore';
+import { arrayUnion, doc, getDoc, serverTimestamp, setDoc, updateDoc } from 'firebase/firestore';
 
 export const createUserProfile = async ({ id, email, name, avatarUrl = '' }) => {
   const userProfile = {
@@ -8,7 +8,7 @@ export const createUserProfile = async ({ id, email, name, avatarUrl = '' }) => 
     name,
     roles: ['USER'],
     cart: [],
-    enrolledCourseIds: [],
+    enrolledCourses: [],
     createdCourses: [],
     avatarUrl,
     createdAt: serverTimestamp(),
@@ -20,13 +20,21 @@ export const createUserProfile = async ({ id, email, name, avatarUrl = '' }) => 
   return userProfile;
 };
 
-// 수정 예정
 export const getUserProfile = async (uid) => {
   try {
-    const snap = await getDoc(doc(db, "users", uid));
-  return snap.exists() ? snap.data() : null;
+    const snap = await getDoc(doc(db, 'users', uid));
+    return snap.exists() ? snap.data() : null;
   } catch (error) {
-    console.error("Error fetching user profile:", error);
+    console.error('Error fetching user profile:', error);
     return null;
   }
-}
+};
+
+export const updateUserToInstructor = async (uid) => {
+  const ref = doc(db, 'users', uid);
+
+  await updateDoc(ref, {
+    roles: arrayUnion('INSTRUCTOR'),
+    updatedAt: serverTimestamp(),
+  });
+};


### PR DESCRIPTION
## 변경 사항

- courseService를 통한 Firestore 강좌 데이터 연동  
- CourseListPage 컴포넌트 및 스타일 수정  
  - 검색·필터 사이드바 구조 준비 (비활성 상태)  
  - BEM 네이밍 규칙 적용 및 스타일 구조 정리  
- CourseCard 목록 렌더링 및 반응형 레이아웃 구성  

## 리뷰 필요

- 반응형 레이아웃(4열 → 2열 전환) 시 카드 높이 균일성 확인  
- SearchBar, FilterSidebar 비활성 상태로 인한 레이아웃 안정성 검토  
- `useAuthState` 구독 로직 변경 영향 확인 (권한/헤더 표시 등 연동 컴포넌트 정상 작동 여부)  
- 홈(강좌 목록) 페이지의 1차 완성 버전으로, 이후 Search/Filter 인터랙션 및 데이터 연동 예정  

close #11
