### PR TITLE
feat: MyPage 내가 등록한 강의 목록 조회 기능 구현

### DIFF
--- a/src/domains/user/components/MyPageSidebar.jsx
+++ b/src/domains/user/components/MyPageSidebar.jsx
@@ -1,7 +1,10 @@
+import { useAuthState } from "@/domains/auth/hooks/useAuthState";
 import styles from '@/domains/user/components/MyPageSidebar.module.css';
+
 import { NavLink } from 'react-router';
 
 export function MyPageSidebar() {
+  const { user } = useAuthState();
   return (
     <>
       <nav
@@ -29,6 +32,7 @@ export function MyPageSidebar() {
           </ul>
         </div>
 
+        {user?.roles?.includes("INSTRUCTOR") && (
         <div
           className={`${styles['mypage-nav__section']} ${styles['mypage-nav__section--instructor']}`}
           aria-label="강사 전용"
@@ -42,6 +46,7 @@ export function MyPageSidebar() {
             </li>
           </ul>
         </div>
+        )}
       </nav>
 
       <details className={`${styles['sidebar']} ${styles['sidebar--collapsible']}`}>

--- a/src/domains/user/pages/MyPageSections.module.css
+++ b/src/domains/user/pages/MyPageSections.module.css
@@ -232,6 +232,10 @@
   gap: var(--space-4);
 }
 
+.authored-section * {
+  text-decoration: none;
+}
+
 .authored {
   display: grid;
   gap: var(--space-3);
@@ -245,10 +249,6 @@
   padding: var(--space-4);
   background: var(--color-elevated);
   /* box-shadow: var(--shadow-sm); */
-}
-
-.authored__item * {
-  text-decoration: none;
 }
 
 .authored__meta {

--- a/src/domains/user/pages/MyPageSections.module.css
+++ b/src/domains/user/pages/MyPageSections.module.css
@@ -247,6 +247,10 @@
   /* box-shadow: var(--shadow-sm); */
 }
 
+.authored__item * {
+  text-decoration: none;
+}
+
 .authored__meta {
   display: grid;
   gap: var(--space-1);

--- a/src/domains/user/pages/instructor/InstructorCourses.jsx
+++ b/src/domains/user/pages/instructor/InstructorCourses.jsx
@@ -53,24 +53,24 @@ export default function InstructorCourses() {
 
       <div className={styles["authored"]}>
         {courses.map((course) => (
-          <div key={course.id} className={styles["authored__item"]}>
-            <NavLink to={`/courses/${course.id}`}>
-              <div className={styles["authored__meta"]}>
-                <h3 className={styles["authored__title"]}>{course.title}</h3>
-                <p className={styles["authored__category"]}>
-                  {Array.isArray(course.category)
-                    ? course.category.join(" / ")
-                    : course.category ?? "카테고리 없음"}
-                </p>
-              </div>
-            </NavLink>
-            <div className={styles["authored__actions"]}>
-              <NavLink to={`/courses/${course.id}/edit`} className={styles["authored__btn"]}>수정</NavLink>
-              <button type="button" className={`${styles["authored__btn"]} ${styles["authored__btn--delete"]}`}>
-                삭제
-              </button>
+          <NavLink to={`/courses/${course.id}`}>
+            <div key={course.id} className={styles["authored__item"]}>
+                <div className={styles["authored__meta"]}>
+                  <h3 className={styles["authored__title"]}>{course.title}</h3>
+                  <p className={styles["authored__category"]}>
+                    {Array.isArray(course.category)
+                      ? course.category.join(" / ")
+                      : course.category ?? "카테고리 없음"}
+                  </p>
+                </div>
+                <div className={styles["authored__actions"]}>
+                  <button className={styles["authored__btn"]}>수정</button>
+                  <button type="button" className={`${styles["authored__btn"]} ${styles["authored__btn--delete"]}`}>
+                    삭제
+                  </button>
+                </div>
             </div>
-          </div>
+          </NavLink>
         ))}
       </div>
     </article>

--- a/src/domains/user/pages/instructor/InstructorCourses.jsx
+++ b/src/domains/user/pages/instructor/InstructorCourses.jsx
@@ -1,7 +1,34 @@
-import React from "react";
+import { useAuthState } from "@/domains/auth/hooks/useAuthState";
 import styles from "@/domains/user/pages/MyPageSections.module.css";
+import { getInstructorCourses } from "@/domains/user/services/instructorService";
+import { useEffect, useState } from "react";
+import { NavLink } from "react-router";
 
 export default function InstructorCourses() {
+  const { user, loading: userLoading } = useAuthState();
+  const [courses, setCourses] = useState([]);
+  const [coursesLoading, setCoursesLoading] = useState(false);
+
+  // user.id 준비된 뒤 → 데이터 가져오기
+  useEffect(() => {
+    if (userLoading || !user?.id) return;
+    setCoursesLoading(true);
+
+    getInstructorCourses(user.id)
+      .then((data) => setCourses(data))
+      .finally(() => setCoursesLoading(false));
+  }, [user, userLoading]);
+
+  // 로딩 UI
+  if (userLoading || coursesLoading) {
+    return <div style={{ padding: "40px" }}>⏳ 강좌 불러오는 중...</div>;
+  }
+
+  // 강좌 없을 때 UI
+  if (courses.length === 0) {
+    return <div style={{ padding: "40px" }}>🫠 개설한 강의가 아직 없어요.</div>;
+  }
+
   return (
     <article
       className={styles["authored-section"]}
@@ -23,39 +50,24 @@ export default function InstructorCourses() {
       </div>
 
       <div className={styles["authored"]}>
-        <div className={styles["authored__item"]}>
-          <div className={styles["authored__meta"]}>
-            <h3 className={styles["authored__title"]}>React 실전 프로젝트</h3>
-            <p className={styles["authored__category"]}>
-              프론트엔드 / React / 실전
-            </p>
+        {courses.map((course) => (
+          <div key={course.id} className={styles["authored__item"]}>
+            <div className={styles["authored__meta"]}>
+              <h3 className={styles["authored__title"]}>{course.title}</h3>
+              <p className={styles["authored__category"]}>
+                {Array.isArray(course.category)
+                  ? course.category.join(" / ")
+                  : course.category ?? "카테고리 없음"}
+              </p>
+            </div>
+            <div className={styles["authored__actions"]}>
+              <NavLink to={`/courses/${course.id}/edit`} className={styles["authored__btn"]}>수정</NavLink>
+              <button type="button" className={`${styles["authored__btn"]} ${styles["authored__btn--delete"]}`}>
+                삭제
+              </button>
+            </div>
           </div>
-          <div className={styles["authored__actions"]}>
-            <a href="/courses/placeholder/edit" className={styles["authored__btn"]}>
-              수정
-            </a>
-            <button type="button" className={`${styles["authored__btn"]} ${styles["authored__btn--delete"]}`}>
-              삭제
-            </button>
-          </div>
-        </div>
-
-        <div className={styles["authored__item"]}>
-          <div className={styles["authored__meta"]}>
-            <h3 className={styles["authored__title"]}>Node.js 백엔드 구조</h3>
-            <p className={styles["authored__category"]}>
-              백엔드 / Node.js / 중급
-            </p>
-          </div>
-          <div className={styles["authored__actions"]}>
-            <a href="/courses/placeholder/edit" className={styles["authored__btn"]}>
-              수정
-            </a>
-            <button type="button" className={`${styles["authored__btn"]} ${styles["authored__btn--delete"]}`}>
-              삭제
-            </button>
-          </div>
-        </div>
+        ))}
       </div>
     </article>
   );

--- a/src/domains/user/pages/instructor/InstructorCourses.jsx
+++ b/src/domains/user/pages/instructor/InstructorCourses.jsx
@@ -10,14 +10,16 @@ export default function InstructorCourses() {
   const [coursesLoading, setCoursesLoading] = useState(false);
 
   // user.id 준비된 뒤 → 데이터 가져오기
-  useEffect(() => {
+    useEffect(() => {
     if (userLoading || !user?.id) return;
     setCoursesLoading(true);
-
     getInstructorCourses(user.id)
-      .then((data) => setCourses(data))
+      .then(setCourses)
+      .catch((err) => {
+        console.error(err);
+      })
       .finally(() => setCoursesLoading(false));
-  }, [user, userLoading]);
+  }, [user?.id, userLoading]);
 
   // 로딩 UI
   if (userLoading || coursesLoading) {
@@ -52,14 +54,16 @@ export default function InstructorCourses() {
       <div className={styles["authored"]}>
         {courses.map((course) => (
           <div key={course.id} className={styles["authored__item"]}>
-            <div className={styles["authored__meta"]}>
-              <h3 className={styles["authored__title"]}>{course.title}</h3>
-              <p className={styles["authored__category"]}>
-                {Array.isArray(course.category)
-                  ? course.category.join(" / ")
-                  : course.category ?? "카테고리 없음"}
-              </p>
-            </div>
+            <NavLink to={`/courses/${course.id}`}>
+              <div className={styles["authored__meta"]}>
+                <h3 className={styles["authored__title"]}>{course.title}</h3>
+                <p className={styles["authored__category"]}>
+                  {Array.isArray(course.category)
+                    ? course.category.join(" / ")
+                    : course.category ?? "카테고리 없음"}
+                </p>
+              </div>
+            </NavLink>
             <div className={styles["authored__actions"]}>
               <NavLink to={`/courses/${course.id}/edit`} className={styles["authored__btn"]}>수정</NavLink>
               <button type="button" className={`${styles["authored__btn"]} ${styles["authored__btn--delete"]}`}>

--- a/src/domains/user/services/instructorService.js
+++ b/src/domains/user/services/instructorService.js
@@ -1,0 +1,22 @@
+import { db } from "@/shared/lib/firebase/firestore";
+import { collection, getDocs, query, where } from "firebase/firestore";
+
+/**
+ * 강사가 개설한 강좌 목록 조회
+ * @param {string} userId - 강사 유저의 ID
+ * @returns {Promise<Array>}
+ */
+
+export async function getInstructorCourses(userId) {
+  const q = query(
+    collection(db, "courses"),
+    where("instructorId", "==", userId)
+  );
+
+  const snap = await getDocs(q);
+
+  return snap.docs.map((doc) => ({
+    id: doc.id,    // 강좌 ID (라우팅/수정 등에 필요)
+    ...doc.data(), // 강좌 상세 데이터(title, category, etc)
+  }));
+}


### PR DESCRIPTION
## 변경 사항

- instructorService 추가 및 getInstructorCourses 구현
- InstructorCourses 페이지에서 user.id 기반 강좌 조회 후 UI에 바인딩
- 로딩 상태 및 빈 목록 상태 처리
- Link 컴포넌트 적용 및 페이지 구조 통일
- 사이드바에서 INSTRUCTOR 권한이 없을 경우 "내가 등록한 강의" 메뉴 숨김 처리

## 리뷰 필요

- 데이터 조회 패턴 / useEffect 의존성 배열 문제 없는지
- UI/컴포넌트 구조 및 네이밍 일관성 문제 없는지

## 테스트 방법

1. INSTRUCTOR 권한이 있는 계정으로 로그인합니다.
2. Firestore `courses` 컬렉션 내 `instructorId` 값이 해당 `user.id` 와 동일한 강의가 존재하는지 확인합니다.
3. 마이페이지 → '내가 등록한 강의' 탭으로 이동합니다.
4. 개설된 강의 목록이 정상적으로 표시되는지 확인합니다.
5. INSTRUCTOR 권한이 없는 계정으로 로그인 시, 사이드바 메뉴에 해당 항목이 숨겨지는지 확인합니다.

close #14
