### PR TITLE
fix: 1차 QA 반영 - 강좌 등록하기 안되는 이슈 해결

### DIFF
--- a/src/domains/course/components/CourseForm.jsx
+++ b/src/domains/course/components/CourseForm.jsx
@@ -25,10 +25,11 @@ export function CourseForm() {
 
   const [sections, setSections] = useState([
     {
-      id: 1, // 프론트엔드 임시 ID
+      id: '',
       title: '', // 섹션 제목
       lectures: [
         {
+          id: '',
           title: '', // 강의 제목
           duration: 0, // 분 단위
           videoUrl: '', // 로컬/Storage URL
@@ -66,8 +67,7 @@ export function CourseForm() {
   };
 
   const handleSectionAdd = () => {
-    const nextId = sections.length + 1;
-    setSections([...sections, { id: nextId, title: `섹션 ${nextId}`, lectures: [] }]);
+    setSections([...sections, { id: crypto.randomUUID(), title: '', lectures: [] }]);
   };
 
   const handleSectionDelete = (sectionId) => {
@@ -81,10 +81,7 @@ export function CourseForm() {
         section.id === sectionId
           ? {
               ...section,
-              lectures: [
-                ...section.lectures,
-                { id: section.lectures.length + 1, title: '새 강의', duration: 0 },
-              ],
+              lectures: [...section.lectures, { id: crypto.randomUUID(), title: '', duration: 0 }],
             }
           : section,
       ),


### PR DESCRIPTION
## 변경 사항

- CourseForm 내 고유 ID 로직을 UUID 기반으로 교체하여 중복 및 참조 오류 해결
- 섹션·강의 추가/삭제 시 참조 안정화
- 불필요한 console.log 제거

## 리뷰 필요

- 섹션/강의 추가·삭제 시 상태 업데이트 성능 및 불변성 처리 방식 점검
- **이전에 종덕님이 말씀하셨던 강좌 내 섹션/강의 삭제 이슈가 해당 ID 로직과 연관된 것으로 보입니다**

close #25
