### PR TITLE
fix: 프로필 아이콘 적용 및 마이페이지/헤더 UI 스타일 개선

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "firebase": "^12.5.0",
+        "lucide-react": "^0.553.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router": "^7.9.5"
@@ -3172,6 +3173,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.553.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.553.0.tgz",
+      "integrity": "sha512-BRgX5zrWmNy/lkVAe0dXBgd7XQdZ3HTf+Hwe3c9WK6dqgnj9h+hxV+MDncM88xDWlCq27+TKvHGE70ViODNILw==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/minimatch": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "firebase": "^12.5.0",
+    "lucide-react": "^0.553.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router": "^7.9.5"

--- a/src/app/global.css
+++ b/src/app/global.css
@@ -1,7 +1,7 @@
 :root {
   color-scheme: light;
   /* brand */
-  --color-brand: #EF6817;
+  --color-brand: #ef6817;
   --color-brand-600: #ff7b2c;
   --color-brand-700: #ff7b2c;
   --color-brand-50: #eef2ff;

--- a/src/domains/course/pages/CourseDetailPage.module.css
+++ b/src/domains/course/pages/CourseDetailPage.module.css
@@ -12,6 +12,8 @@
 .course-detail__hero {
   width: 100%;
   grid-column: 1 / -1;
+  height: clamp(200px, 30vw, 360px);
+  object-fit: cover;
   min-height: 240px;
   border-radius: var(--radius-lg);
   background: var(--color-elevated);
@@ -253,6 +255,6 @@
 
 @media (min-width: 1200px) {
   .course-detail__hero {
-    min-height: 360px;
+    min-height: 300px;
   }
 }

--- a/src/domains/course/pages/CourseListPage.jsx
+++ b/src/domains/course/pages/CourseListPage.jsx
@@ -25,46 +25,17 @@ export default function CourseListPage() {
   return (
     <main className={`${styles['course-list']} container`} aria-label="강좌 목록">
       {/* 본문 */}
-      <div
-        style={{
-          transform: 'translateX(-25%)',
-          width: '200%',
-          minHeight: '300px',
-          background: 'black',
-          color: '#fff',
-          display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'center',
-          alignItems: 'center',
-          borderRadius: '30px',
-          marginBottom: '50px',
-          padding: '60px 40px',
-          gap: '30px',
-        }}
-      >
-        {/* 메인 문구 */}
-        <div
-          style={{
-            fontSize: '50px',
-            fontWeight: '700',
-            textAlign: 'center',
-            lineHeight: '1.3',
-          }}
-        >
-          강사, 학생 둘 다 되는 게 <span style={{ color: '#FF8C42' }}>런피</span>
-        </div>
+      <div className={styles['bannerContainer']}>
+        <div className={styles['bannerContent']}>
+          {/* 메인 문구 */}
+          <div className={styles['mainText']}>
+            강사, 학생 둘 다 되는 게 <span className={styles['highlightText']}>런피</span>
+          </div>
 
-        {/* 보조 문구 */}
-        <div
-          style={{
-            fontSize: '22px',
-            fontWeight: '400',
-            color: 'rgba(255, 255, 255, 0.85)',
-            textAlign: 'center',
-            lineHeight: '1.5',
-          }}
-        >
-          한 번의 클릭으로 배움과 가르침을 모두 경험하세요
+          {/* 보조 문구 */}
+          <div className={styles['subText']}>
+            한 번의 클릭으로 배움과 가르침을 모두 경험하세요
+          </div>
         </div>
       </div>
       <section className={styles['course-list__content']} aria-label="강좌 카드 목록">

--- a/src/domains/course/pages/CourseListPage.module.css
+++ b/src/domains/course/pages/CourseListPage.module.css
@@ -1,3 +1,43 @@
+.bannerContainer {
+  position: relative;
+  width: calc(100% + 40px);
+  transform: translateX(-20px);
+  overflow: hidden;
+}
+
+.bannerContent {
+  transform: translateX(-25%);
+  width: 200%;
+  min-height: 300px;
+  background: black;
+  color: #fff;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  border-radius: 30px;
+  margin-bottom: 50px;
+  padding: 60px 40px;
+  gap: 30px;
+}
+
+.mainText {
+  font-size: 50px;
+  font-weight: 700;
+  line-height: 1.3;
+}
+
+.highlightText {
+  color: #FF8C42;
+}
+
+.subText {
+  font-size: 22px;
+  font-weight: 400;
+  color: rgba(255, 255, 255, 0.85);
+  line-height: 1.5;
+}
+
 .course-list {
   display: grid;
   gap: var(--space-5);

--- a/src/domains/user/components/MyPageSidebar.module.css
+++ b/src/domains/user/components/MyPageSidebar.module.css
@@ -95,9 +95,9 @@
 }
 
 .mypage-nav__item:has(.mypage-nav__link[aria-current="page"]) .mypage-nav__link {
-  background: linear-gradient(90deg, var(--color-brand), var(--color-brand-700));
-  border-color: transparent;
-  color: var(--color-text-light);
+  border-color: var(--color-brand);
+  color: var(--color-brand);
+  font-weight: bold;
 }
 
 .mypage-nav__section {

--- a/src/domains/user/pages/MyPageSections.module.css
+++ b/src/domains/user/pages/MyPageSections.module.css
@@ -29,8 +29,18 @@
   width: 72px;
   height: 72px;
   border-radius: 50%;
-  background: var(--color-brand);
-  border: 1px solid var(--color-border);
+  background-color: #f1f3f5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+
+.profile-section__icon {
+  width: 50px;
+  height: 50px;
+  color: #666; /* 아이콘 기본 색상 */
+  stroke-width: 1.6;
 }
 
 .profile-section__identity {
@@ -87,15 +97,9 @@
   border-color: var(--color-brand);
 }
 
-.profile__btn--edit {
-  background: var(--color-brand);
-  border-color: var(--color-brand);
-  color: var(--color-text-light);
-}
-
 .profile__btn--edit:hover,
 .profile__btn--edit:focus-visible {
-  background: var(--color-brand-700);
+  color: var(--color-brand);
 }
 
 .profile-section__row {

--- a/src/domains/user/pages/Profile.jsx
+++ b/src/domains/user/pages/Profile.jsx
@@ -1,6 +1,8 @@
 import styles from '@/domains/user/pages/MyPageSections.module.css';
 import { formatUserDate } from "@/domains/user/utils/formatUserDate";
+import { User } from "lucide-react";
 import { useAuthState } from '../../auth/hooks/useAuthState';
+
 
 export default function Profile() {
   const { user, loading } = useAuthState();
@@ -25,7 +27,9 @@ export default function Profile() {
 
       {/* 프로필 헤더 카드 */}
       <section className={styles['profile-section__header-card']} aria-label="프로필 요약">
-        <div className={styles['profile-section__avatar']} aria-hidden="true" />
+        <div className={styles['profile-section__avatar']} aria-hidden="true" >
+          <User className={styles['profile-section__icon']} />
+        </div>
         <div className={styles['profile-section__identity']}>
           <h2 className={styles['profile-section__name']}>{user.name}님</h2>
           <p className={styles['profile-section__email']}>{user.email}</p>

--- a/src/shared/ui/Header.jsx
+++ b/src/shared/ui/Header.jsx
@@ -3,6 +3,7 @@ import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import { logout } from '@/domains/auth/services/authService';
 import { RoleRequestModal } from '@/domains/user/components/RoleRequestModal';
 import { useModal } from '@/shared/hooks/useModal';
+import { User } from "lucide-react";
 import { useEffect, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router';
 import styles from './Header.module.css';
@@ -114,9 +115,10 @@ export function Header() {
                   onClick={() => setMenuOpen((prev) => !prev)}
                   className={styles['header__profile']}
                 >
-                  <span className={styles['header__avatar']}>
+                  {/* <span className={styles['header__avatar']}>
                     {user.displayName?.[0]?.toUpperCase() ?? 'U'}
-                  </span>
+                  </span> */}
+                  <User className={styles['header__profile-icon']} />
                 </button>
 
                 {menuOpen && (

--- a/src/shared/ui/Header.module.css
+++ b/src/shared/ui/Header.module.css
@@ -113,9 +113,11 @@
 }
 
 .header__action--cta {
-  background: var(--color-brand);
-  color: var(--color-text-light);
-  border-color: var(--color-brand);
+  border: 1px solid var(--color-border);
+  transition: border-color 0.2s 
+ease, background 0.2s 
+ease, color 0.2s 
+ease;
 }
 
 .header__action--cta:hover,
@@ -131,8 +133,8 @@
   width: 40px;
   height: 40px;
   border-radius: 999px;
-  background: linear-gradient(135deg, var(--color-brand), var(--color-brand-700));
-  color: var(--color-text);
+  background: #f1f3f5;
+  color: #666;
   font-weight: 700;
   text-decoration: none;
   transition: transform 0.2s ease;


### PR DESCRIPTION
## 변경 사항

- Header 프로필 버튼에 lucide-react `User` 아이콘 적용 (기존 이니셜 텍스트 대체)
- 마이페이지 프로필 섹션에 아바타 컨테이너 및 기본 프로필 아이콘 스타일 추가
- MyPageSections / Header 등 관련 CSS 모듈에서 탭·버튼·아이콘 정렬 및 여백 스타일 보정
- global.css 포함 UI 공통 스타일 일부 정리 (일관성 유지 목적의 소폭 수정)

## 리뷰 필요

- Header 프로필 아이콘/버튼 UI가 현재 디자인 가이드 및 기획 의도와 잘 맞는지
- 마이페이지 탭·버튼·프로필 영역 스타일 변경이 다른 페이지/반응형 레이아웃에 부작용 없는지
- lucide-react 추가에 따른 아이콘 스타일(두께/크기)이 전체 서비스 톤앤매너와 어색하지 않은지

close #26
