### PR TITLE
fix: 1차 QA - 강좌 상세 페이지 이슈 해결

### DIFF
--- a/src/domains/course/components/FloatingCTA.jsx
+++ b/src/domains/course/components/FloatingCTA.jsx
@@ -4,6 +4,7 @@ export function FloatingCTA({
   price,
   isFree,
   isEnrolled,
+  isOwner,
   instructorName,
   totalLectures,
   totalTime,
@@ -26,12 +27,12 @@ export function FloatingCTA({
           <button
             type="button"
             className={`${styles['floating-cta__button']} ${
-              isEnrolled ? styles['floating-cta__button--disabled'] : ''
+              isEnrolled || isOwner ? styles['floating-cta__button--disabled'] : ''
             }`}
             onClick={onApply}
-            disabled={isEnrolled}
+            disabled={isEnrolled || isOwner}
           >
-            {isEnrolled ? '수강중' : '수강신청하기'}
+            {isOwner ? '내가 등록한 강좌' : isEnrolled ? '수강중' : '수강신청하기'}
           </button>
 
           {/* 장바구니 버튼 */}

--- a/src/domains/course/pages/CourseDetailPage.jsx
+++ b/src/domains/course/pages/CourseDetailPage.jsx
@@ -122,7 +122,33 @@ export default function CourseDetailPage() {
                     <ul>
                       {lectures[sec.id]?.map((lec) => (
                         <li key={lec.id}>
-                          {lec.title} ({lec.duration}분)
+                          <div className={styles['course-detail__lecture']}>
+                            <span className={styles['course-detail__lecture-title']}>
+                              {lec.title} ({lec.duration}분)
+                            </span>
+
+                            {/* 잠금 상태 */}
+                            {!isEnrolled && (
+                              <div className={styles['course-detail__lecture-locked']}>
+                                <span className={styles['course-detail__lecture-lock-icon']}>
+                                  🔒
+                                </span>
+                                <span className={styles['course-detail__lecture-lock-text']}>
+                                  수강 후 열람 가능
+                                </span>
+                              </div>
+                            )}
+
+                            {/* 재생 버튼 */}
+                            {lec.videoUrl && isEnrolled && (
+                              <button
+                                className={styles['course-detail__lecture-play']}
+                                onClick={() => openVideoPlayer(lec.videoUrl)}
+                              >
+                                재생
+                              </button>
+                            )}
+                          </div>
                         </li>
                       ))}
                     </ul>

--- a/src/domains/course/pages/CourseDetailPage.jsx
+++ b/src/domains/course/pages/CourseDetailPage.jsx
@@ -45,6 +45,8 @@ export default function CourseDetailPage() {
   const totalLectures = sections.reduce((sum, sec) => sum + (lectures[sec.id]?.length || 0), 0);
   const courseInfo = { ...course, totalLectures };
 
+  const isOwner = user?.id === course.instructorId;
+
   return (
     <main className={`${styles['course-detail']} container`} aria-labelledby="course-detail-title">
       <div className={styles['course-detail__layout']}>
@@ -128,7 +130,7 @@ export default function CourseDetailPage() {
                             </span>
 
                             {/* 잠금 상태 */}
-                            {!isEnrolled && (
+                            {!isEnrolled && !isOwner && (
                               <div className={styles['course-detail__lecture-locked']}>
                                 <span className={styles['course-detail__lecture-lock-icon']}>
                                   🔒
@@ -140,7 +142,7 @@ export default function CourseDetailPage() {
                             )}
 
                             {/* 재생 버튼 */}
-                            {lec.videoUrl && isEnrolled && (
+                            {lec.videoUrl && (isEnrolled || isOwner) && (
                               <button
                                 className={styles['course-detail__lecture-play']}
                                 onClick={() => openVideoPlayer(lec.videoUrl)}
@@ -172,6 +174,7 @@ export default function CourseDetailPage() {
           isFree={course.isFree}
           isEnrolled={isEnrolled}
           onApply={handleApplyClick}
+          isOwner={isOwner}
           instructorName={course.instructorName}
           totalLectures={courseInfo.totalLectures}
           totalTime={formatDuration(course.duration)}

--- a/src/domains/course/pages/CourseDetailPage.module.css
+++ b/src/domains/course/pages/CourseDetailPage.module.css
@@ -236,6 +236,59 @@
   background: var(--color-border);
 }
 
+.course-detail__lecture {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-2) 0;
+  gap: var(--space-3);
+}
+
+.course-detail__lecture-title {
+  display: flex;
+  flex-direction: row;
+  flex: 1;
+  font-size: var(--text-base);
+}
+
+/* 🔒 잠금 상태 */
+.course-detail__lecture-locked {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  background: var(--color-gray-100);
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+  padding: 4px 8px;
+  border-radius: var(--radius-sm);
+  white-space: nowrap;
+}
+
+.course-detail__lecture-lock-icon {
+  font-size: 14px;
+}
+
+.course-detail__lecture-lock-text {
+  white-space: nowrap;
+}
+
+/* ▶ 재생 버튼 */
+.course-detail__lecture-play {
+  background: var(--color-brand);
+  color: white;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  font-size: var(--text-sm);
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.2s ease;
+}
+
+.course-detail__lecture-play:hover {
+  background: var(--color-brand-700);
+}
+
 @media (min-width: 768px) {
   .course-detail__layout {
     grid-template-columns: minmax(0, 3fr) minmax(0, 1fr);
@@ -250,6 +303,17 @@
     position: sticky;
     top: var(--space-11);
     align-self: start;
+  }
+
+  .course-detail__lecture {
+    flex-direction: row;
+    align-items: flex-start;
+    gap: var(--space-2);
+  }
+
+  .course-detail__lecture-play,
+  .course-detail__lecture-locked {
+    align-self: flex-end;
   }
 }
 


### PR DESCRIPTION
## 변경 사항

* 수강 신청 완료된 사용자가 커리큘럼 탭 접근 시, 각 강의별 **동영상 재생 버튼이 정상적으로 노출되도록 로직 수정**
* 강사가 본인이 생성한 강좌 상세 페이지에 접근할 경우, FloatingCTA의 **‘수강신청하기’ 버튼을 ‘내가 등록한 강좌’로 변경하고 비활성화 처리**

## 리뷰 필요

* 재생 버튼 조건 적용이 실제 사용자 플로우와 충돌 없는지 검증 필요

close #32
