### PR TITLE
refactor: 강좌 등록 페이지 Next.js + TS 마이그레이션

### DIFF
--- a/src/app/courses/create/page.tsx
+++ b/src/app/courses/create/page.tsx
@@ -1,3 +1,21 @@
+import styles from './CourseCreatePage.module.css';
+import { CourseForm } from '@/domains/course/components/CourseForm';
+
 export default function CourseCreatePage() {
-  return <div></div>;
+  return (
+    <section
+      className={`${styles['course-create']} container`}
+      aria-labelledby="course-create-title"
+    >
+      <header className={styles['course-create__header']}>
+        <h1 id="course-create-title" className={styles['course-create__title']}>
+          강좌 등록
+        </h1>
+      </header>
+
+      <div className={styles['course-create__body']}>
+        <CourseForm />
+      </div>
+    </section>
+  );
 }

--- a/src/domains/course/components/CourseForm.tsx
+++ b/src/domains/course/components/CourseForm.tsx
@@ -1,99 +1,185 @@
+'use client';
+
+import { useState, type ChangeEvent, type FormEvent } from 'react';
+import { useRouter } from 'next/navigation';
+
 import Link from 'next/link';
-import { useState } from 'react';
-import { useNavigate } from 'react-router';
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
-import { useCourseCreate } from '@/domains/course/hooks/useCourseCreate';
+import { createCourse } from '@/domains/course/services/courseService';
+import type {
+  CreateCourseRequest,
+  CreateSectionRequest,
+  CreateLectureRequest,
+} from '@/domains/course/types/course';
 import { validateForm } from '@/shared/util/validateForm';
-import styles from './CourseForm.module.css';
+
 import { LectureUploader } from './LectureUploader';
 import { SelectCategory } from './SelectCategory';
 import { ThumbnailUploader } from './ThumbnailUploader';
+import styles from './CourseForm.module.css';
+
+type CourseForm = {
+  title: string;
+  summary: string;
+  description: string;
+  category: string[];
+  level: string;
+  price: number | ''; // input 제어용
+  thumbnailUrl: string;
+};
+
+type LectureDraft = CreateLectureRequest & {
+  id: string;
+};
+
+type SectionDraft = {
+  id: string;
+  title: string;
+  lectures: LectureDraft[];
+};
+
+const createEmptyLecture = (): LectureDraft => ({
+  id:
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : String(Date.now() + Math.random()),
+  title: '',
+  duration: 0,
+  videoUrl: '',
+});
+
+const createEmptySection = (): SectionDraft => ({
+  id:
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto
+      ? crypto.randomUUID()
+      : String(Date.now() + Math.random()),
+  title: '',
+  lectures: [createEmptyLecture()],
+});
 
 export function CourseForm() {
-  const navigate = useNavigate();
+  const router = useRouter();
   const { user } = useAuthState();
-  const { createCourse, loading, error, success } = useCourseCreate();
 
-  const [formData, setFormData] = useState({
+  const [formData, setFormData] = useState<CourseForm>({
     title: '',
     summary: '',
     description: '',
     category: [],
     level: '',
-    price: 0,
+    price: '',
     thumbnailUrl: '',
   });
 
-  const [sections, setSections] = useState([
-    {
-      id: '',
-      title: '', // 섹션 제목
-      lectures: [
-        {
-          id: '',
-          title: '', // 강의 제목
-          duration: 0, // 분 단위
-          videoUrl: '', // 로컬/Storage URL
-        },
-      ],
-    },
-  ]);
-  const isInvalid =
-    validateForm(formData) || // 기본 입력값 검사
-    sections.length === 0 || // 섹션이 하나도 없을 때
+  const [sections, setSections] = useState<SectionDraft[]>([createEmptySection()]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+  const [success, setSuccess] = useState(false);
+
+  // 기본 입력값 검사 + 섹션/강의 유효성
+  const baseInvalid = validateForm(formData);
+  const structureInvalid =
+    sections.length === 0 ||
     sections.some(
       (section) =>
-        !section.title.trim() || // 섹션 제목이 비어 있음
-        section.lectures.length === 0 || // 강의가 없음
+        !section.title.trim() ||
+        section.lectures.length === 0 ||
         section.lectures.some(
-          (lecture) => !lecture.title.trim() || !lecture.videoUrl.trim(), // 강의 제목 또는 영상이 비어 있음
+          (lecture) => !lecture.title.trim() || !lecture.videoUrl || !lecture.videoUrl.trim(),
         ),
     );
+  const isInvalid = baseInvalid || structureInvalid;
 
-  const handleChange = (e) => {
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>,
+  ) => {
     const { id, value } = e.target;
-    setFormData((prev) => ({ ...prev, [id]: value }));
+
+    setFormData((prev) => ({
+      ...prev,
+      [id]: id === 'price' ? (value === '' ? '' : Number(value)) : value,
+    }));
   };
 
-  const handleCourseCreate = async (e) => {
+  const handleCourseCreate = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!user) return alert('로그인이 필요합니다.');
+    if (!user) {
+      alert('로그인이 필요합니다.');
+      return;
+    }
+    if (isInvalid) {
+      alert('필수 정보를 모두 입력해주세요.');
+      return;
+    }
+
+    setError('');
+    setSuccess(false);
+    setLoading(true);
+
     try {
-      console.log(formData);
-      const courseId = await createCourse(user, formData, sections);
-      navigate(`/courses/${courseId}`);
+      // CreateCourseRequest으로 매핑
+      const courseInput: CreateCourseRequest = {
+        title: formData.title,
+        summary: formData.summary,
+        description: formData.description,
+        thumbnailUrl: formData.thumbnailUrl,
+        category: formData.category,
+        level: formData.level,
+        price: Number(formData.price || 0),
+      };
+
+      // CreateSectionRequest으로 매핑 (id 제거)
+      const sectionInput: CreateSectionRequest[] = sections.map((section) => ({
+        title: section.title,
+        lectures: section.lectures.map<CreateLectureRequest>((lecture) => ({
+          title: lecture.title,
+          videoUrl: lecture.videoUrl,
+          duration: lecture.duration,
+        })),
+      }));
+
+      const courseId = await createCourse(user, courseInput, sectionInput);
+      setSuccess(true);
+      router.replace(`/courses/${courseId}`);
     } catch (err) {
-      console.error('등록 실패: ' + err.message);
+      console.error(err);
+      setError(err instanceof Error ? err.message : '강좌 등록 중 오류가 발생했습니다.');
+    } finally {
+      setLoading(false);
     }
   };
 
   const handleSectionAdd = () => {
-    setSections([...sections, { id: crypto.randomUUID(), title: '', lectures: [] }]);
+    setSections((prev) => [...prev, createEmptySection()]);
   };
 
-  const handleSectionDelete = (sectionId) => {
+  const handleSectionDelete = (sectionId: string) => {
     if (!window.confirm('정말 이 섹션을 삭제하시겠습니까?')) return;
-    setSections(sections.filter((s) => s.id !== sectionId));
+    setSections((prev) => prev.filter((s) => s.id !== sectionId));
   };
 
-  const handleLectureAdd = (sectionId) => {
+  const handleLectureAdd = (sectionId: string) => {
     setSections((prev) =>
       prev.map((section) =>
         section.id === sectionId
           ? {
               ...section,
-              lectures: [...section.lectures, { id: crypto.randomUUID(), title: '', duration: 0 }],
+              lectures: [...section.lectures, createEmptyLecture()],
             }
           : section,
       ),
     );
   };
 
-  /** 강의 삭제 */
-  const handleLectureDelete = (sectionId, lectureId) => {
+  const handleLectureDelete = (sectionId: string, lectureId: string) => {
     setSections((prev) =>
-      prev.map((s) =>
-        s.id === sectionId ? { ...s, lectures: s.lectures.filter((l) => l.id !== lectureId) } : s,
+      prev.map((section) =>
+        section.id === sectionId
+          ? {
+              ...section,
+              lectures: section.lectures.filter((lec) => lec.id !== lectureId),
+            }
+          : section,
       ),
     );
   };
@@ -140,7 +226,7 @@ export function CourseForm() {
             </label>
             <textarea
               id="description"
-              rows="6"
+              rows={6}
               value={formData.description}
               onChange={handleChange}
               className={styles['course-form__textarea']}
@@ -209,11 +295,12 @@ export function CourseForm() {
         </div>
       </div>
 
-      {/* 섹션 영역 */}
+      {/* 섹션 / 강의 구성 */}
       <div className={styles['course-form__field']}>
         <label htmlFor="lecture" className={styles['form__label']}>
           섹션 <span className={styles['course-form__req']}>*</span>
         </label>
+
         <section className={styles['sections']} aria-label="섹션 구성">
           {sections.map((section, sectionIdx) => (
             <div key={section.id} className={styles['section']}>
@@ -266,6 +353,7 @@ export function CourseForm() {
                         placeholder="강의 제목 입력"
                       />
                     </div>
+
                     <LectureUploader
                       onUploadComplete={({ videoUrl, duration }) => {
                         setSections((prev) =>
@@ -314,8 +402,12 @@ export function CourseForm() {
         </section>
       </div>
 
-      {/* 저장/취소 버튼 */}
+      {/* 저장/취소 */}
+
       <div className={styles['form-actions']}>
+        <Link href="/courses" className={`${styles['btn']} ${styles['btn--ghost']}`}>
+          취소
+        </Link>
         <button
           type="submit"
           disabled={loading || isInvalid}
@@ -323,9 +415,6 @@ export function CourseForm() {
         >
           {loading ? '등록 중...' : '등록하기'}
         </button>
-        <Link href="/courses" className={`${styles['btn']} ${styles['btn--ghost']}`}>
-          취소
-        </Link>
       </div>
 
       {error && <p style={{ color: 'red' }}>오류: {error}</p>}

--- a/src/domains/course/components/LectureUploader.tsx
+++ b/src/domains/course/components/LectureUploader.tsx
@@ -1,52 +1,55 @@
-import { useState } from 'react';
+'use client';
+
+import { useState, type ChangeEvent } from 'react';
 import { formatDuration } from '../utils/formatDuration';
 import styles from './CourseForm.module.css';
 
-/**
- * LectureUploader
- * - 로컬 비디오 미리보기 + 재생시간(duration) 자동 계산
- */
-export function LectureUploader({ onUploadComplete }) {
+type LectureUploaderProps = {
+  onUploadComplete?: (payload: { videoUrl: string; duration: number }) => void;
+};
+
+export function LectureUploader({ onUploadComplete }: LectureUploaderProps) {
   const [uploading, setUploading] = useState(false);
   const [fileName, setFileName] = useState('');
   const [videoUrl, setVideoUrl] = useState('');
-  const [duration, setDuration] = useState('');
+  const [duration, setDuration] = useState<number | null>(null);
 
-  const handleFileChange = async (e) => {
+  const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
+
     setUploading(true);
     setFileName(file.name);
 
     try {
       const url = URL.createObjectURL(file);
 
-      // 비디오 메타데이터 로드 후 duration 계산
       const tempVideo = document.createElement('video');
       tempVideo.preload = 'metadata';
       tempVideo.src = url;
+
       tempVideo.onloadedmetadata = () => {
-        const totalSeconds = tempVideo.duration;
+        const totalSeconds = tempVideo.duration || 0;
         const totalMinutes = Math.floor(totalSeconds / 60);
+
         setDuration(totalMinutes);
         setVideoUrl(url);
         setUploading(false);
 
-        // 부모 컴포넌트에 전달
         onUploadComplete?.({
           videoUrl: url,
-          duration: Number(totalMinutes.toFixed(2)), //  분 단위 숫자
+          duration: totalMinutes,
         });
       };
     } catch (err) {
-      alert('비디오 처리 중 오류가 발생했습니다: ' + err.message);
+      const msg = err instanceof Error ? err.message : '비디오 처리 중 오류가 발생했습니다.';
+      alert(msg);
       setUploading(false);
     }
   };
 
   return (
     <div className={styles['upload-card']}>
-      {/* 파일 선택 */}
       <input
         type="file"
         accept="video/*"
@@ -55,15 +58,17 @@ export function LectureUploader({ onUploadComplete }) {
         className={styles['form__control']}
       />
 
-      {uploading && <p className={styles['upload__hint']}>업로드 중... </p>}
+      {uploading && <p className={styles['upload__hint']}>업로드 중...</p>}
+
       {videoUrl && <video src={videoUrl} controls className={styles['upload__preview']} />}
+
       {fileName && !uploading && (
         <p className={styles['upload__hint']}>
-          {fileName} {duration && `(${formatDuration(duration)})`}
+          {fileName}
+          {duration !== null && ` (${formatDuration(duration)})`}
         </p>
       )}
 
-      {/* 안내문 */}
       {!fileName && (
         <p className={styles['upload__hint']}>
           MP4, WebM 형식의 비디오를 업로드하세요 (최대 200MB 권장)

--- a/src/domains/course/components/SelectCategory.tsx
+++ b/src/domains/course/components/SelectCategory.tsx
@@ -1,34 +1,44 @@
-import { useEffect, useState } from 'react';
+'use client';
+
+import { ChangeEvent } from 'react';
 import { CATEGORY } from '../constants/category';
 import styles from './CourseForm.module.css';
 
-export function SelectCategory({ value = [], onChange }) {
-  const [first, setFirst] = useState(value[0] || '');
-  const [second, setSecond] = useState(value[1] || '');
-  const [third, setThird] = useState(value[2] || '');
+type SelectCategoryProps = {
+  value?: string[];
+  onChange?: (value: string[]) => void;
+  id?: string;
+};
 
-  const firstCategories = Object.keys(CATEGORY).filter((key) => key !== '전체');
-  const secondCategories = first ? Object.keys(CATEGORY[first]) : [];
-  const thirdCategories = first && second ? CATEGORY[first][second] || [] : [];
+type CategoryObject = Record<string, Record<string, string[]>>;
 
-  // 첫, 두, 세 카테고리 중 하나라도 바뀌면 상위로 알림
-  useEffect(() => {
-    if (onChange) onChange([first, second, third].filter(Boolean));
-  }, [first, second, third, onChange]);
+const CATEGORY_OBJ = CATEGORY as CategoryObject;
 
-  const handleFirstChange = (e) => {
-    setFirst(e.target.value);
-    setSecond('');
-    setThird('');
+export function SelectCategory({ value = [], onChange, id }: SelectCategoryProps) {
+  const first = value[0] ?? '';
+  const second = value[1] ?? '';
+  const third = value[2] ?? '';
+
+  const firstCategories = Object.keys(CATEGORY_OBJ).filter((key) => key !== '전체');
+  const secondCategories = first ? Object.keys(CATEGORY_OBJ[first] ?? {}) : [];
+  const thirdCategories = first && second ? (CATEGORY_OBJ[first]?.[second] ?? []) : [];
+
+  const handleFirstChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const nextFirst = e.target.value;
+    // 1차만 선택된 상태로 리셋
+    onChange?.([nextFirst]);
   };
 
-  const handleSecondChange = (e) => {
-    setSecond(e.target.value);
-    setThird('');
+  const handleSecondChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const nextSecond = e.target.value;
+    // 1차 + 2차까지만
+    onChange?.([first, nextSecond]);
   };
 
-  const handleThirdChange = (e) => {
-    setThird(e.target.value);
+  const handleThirdChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const nextThird = e.target.value;
+    // 1차 + 2차 + 3차
+    onChange?.([first, second, nextThird]);
   };
 
   return (
@@ -36,6 +46,7 @@ export function SelectCategory({ value = [], onChange }) {
       <div className={styles['course-form__category-group']}>
         {/* 1차 카테고리 */}
         <select
+          id={id}
           value={first}
           onChange={handleFirstChange}
           className={styles['course-form__select']}
@@ -85,7 +96,6 @@ export function SelectCategory({ value = [], onChange }) {
         </select>
       </div>
 
-      {/* 선택 상태 표시 */}
       <p className={styles['course-form__hint']}>
         선택된 카테고리:{' '}
         {first && second && third ? `${first} > ${second} > ${third}` : '아직 선택되지 않음'}

--- a/src/domains/course/components/ThumbnailUploader.tsx
+++ b/src/domains/course/components/ThumbnailUploader.tsx
@@ -1,17 +1,23 @@
+'use client';
+
+import { useState, type ChangeEvent } from 'react';
 import Image from 'next/image';
-import { useState } from 'react';
 import styles from './CourseForm.module.css';
 
-export function ThumbnailUploader({ onUploadComplete }) {
-  const [thumbnailUrl, setThumbnailUrl] = useState(null);
+type ThumbnailUploaderProps = {
+  onUploadComplete?: (url: string) => void;
+};
 
-  const handleFileChange = async (e) => {
+export function ThumbnailUploader({ onUploadComplete }: ThumbnailUploaderProps) {
+  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+
+  const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
     const reader = new FileReader();
     reader.onload = () => {
-      const base64Url = reader.result;
+      const base64Url = String(reader.result ?? '');
       setThumbnailUrl(base64Url);
       onUploadComplete?.(base64Url);
     };
@@ -22,7 +28,7 @@ export function ThumbnailUploader({ onUploadComplete }) {
     <aside className={styles['upload-card']}>
       {thumbnailUrl && (
         <div className={styles['upload__preview']}>
-          <Image src={thumbnailUrl} alt="썸네일 미리보기" />
+          <Image src={thumbnailUrl} alt="썸네일 미리보기" width={320} height={200} />
         </div>
       )}
 

--- a/src/domains/course/services/courseService.ts
+++ b/src/domains/course/services/courseService.ts
@@ -21,8 +21,8 @@ import type {
   Section,
   Lecture,
   CourseDetailResponse,
-  CreateCourseInput,
-  CreateSectionInput,
+  CreateCourseRequest,
+  CreateSectionRequest,
 } from '../types/course';
 
 export const getAllCourses = async (): Promise<Course[]> => {
@@ -142,8 +142,8 @@ export const getEnrollmentStatus = async (userId: string, courseId: string): Pro
 
 export const createCourse = async (
   user: User,
-  courseData: CreateCourseInput,
-  sectionList: CreateSectionInput[],
+  courseData: CreateCourseRequest,
+  sectionList: CreateSectionRequest[],
 ): Promise<string> => {
   if (!user?.id) throw new Error('로그인이 필요합니다.');
 

--- a/src/domains/course/services/courseService.ts
+++ b/src/domains/course/services/courseService.ts
@@ -15,6 +15,7 @@ import {
 } from 'firebase/firestore';
 import { db } from '@/shared/lib/firebase/firestore';
 
+import type { User } from '@/domains/user/types/user';
 import type {
   Course,
   Section,
@@ -23,7 +24,6 @@ import type {
   CreateCourseInput,
   CreateSectionInput,
 } from '../types/course';
-import type { User } from '@/domains/user/types/user';
 
 export const getAllCourses = async (): Promise<Course[]> => {
   try {

--- a/src/domains/course/types/course.ts
+++ b/src/domains/course/types/course.ts
@@ -62,18 +62,19 @@ export type CourseDetailResponse = {
   lectures: Record<string, Lecture[]>;
 };
 
-export type CreateLectureInput = {
+/** 요청 DTO 쪽 네이밍 */
+export type CreateLectureRequest = {
   title: string;
   videoUrl?: string;
   duration: number;
 };
 
-export type CreateSectionInput = {
+export type CreateSectionRequest = {
   title: string;
-  lectures: CreateLectureInput[];
+  lectures: CreateLectureRequest[];
 };
 
-export type CreateCourseInput = {
+export type CreateCourseRequest = {
   title: string;
   summary: string;
   description: string;

--- a/src/domains/course/utils/formatDuration.js
+++ b/src/domains/course/utils/formatDuration.js
@@ -1,8 +1,0 @@
-export const formatDuration = (totalMinutes) => {
-  if (!totalMinutes || isNaN(totalMinutes)) return '0분';
-  const hours = Math.floor(totalMinutes / 60);
-  const minutes = totalMinutes % 60;
-  if (hours === 0) return `${minutes}분`;
-  if (minutes === 0) return `${hours}시간`;
-  return `${hours}시간 ${minutes}분`;
-};


### PR DESCRIPTION
## 변경 사항

- 강좌 등록 페이지를 Next(App Router) + TypeScript 기준으로 마이그레이션
  - `CourseForm`를 클라이언트 컴포넌트로 전환하고 `useRouter` 기반 내비게이션으로 변경
  - 폼 상태를 타입 기반으로 정리 (`CourseForm`, `SectionDraft`, `LectureDraft`)
  - 제출 시 `createCourse` 서비스에서 사용하는  
    `CreateCourseRequest` / `CreateSectionRequest` / `CreateLectureRequest` 형태로 매핑
- 강좌 등록 페이지 서버 컴포넌트 추가
  - `app/courses/create/page.tsx`에서 `CourseForm` 렌더링하도록 구성
- 강좌 생성 관련 타입 네이밍 정리
  - `CreateCourseInput` → `CreateCourseRequest` 등 Request 계열 타입 이름 통일
- 강좌 등록 서브 컴포넌트 TS 마이그레이션
  - `SelectCategory`, `ThumbnailUploader`, `LectureUploader` TS로 변환 및 props 타입 명시
- 기타
  - `formatDuration.js` 제거 및 관련 코드 TS로 이전
  - `courseService.ts` 린트/포맷팅 정리 (동작 변경 없음)

## 리뷰 필요

- 필수 정보 + 섹션/강의가 모두 채워졌을 때 강좌가 정상 생성되고, 생성 후 `/courses/[id]`로 이동하는지


Closes #53
