### PR TITLE
feat: 강좌 학습 페이지 UI 추가

### DIFF
--- a/src/app/courses/[id]/learn/CourseLearnPage.module.css
+++ b/src/app/courses/[id]/learn/CourseLearnPage.module.css
@@ -1,17 +1,8 @@
-:root {
-  /* use global design tokens where possible */
-  --brand: var(--color-brand);
-  --brand-foreground: var(--color-text-light);
-  --muted: var(--color-text-muted);
-  --card-bg: var(--color-surface);
-  --bg: var(--color-bg);
-  --border: var(--color-border);
-  --accent: rgba(239,104,23,0.08); /* subtle brand tint */
-}
-
 .course-learn {
+  /* use global tokens from src/app/global.css; only define local accent */
+  --accent: rgba(239,104,23,0.08);
   min-height: 100vh;
-  background: var(--bg);
+  background: var(--color-bg);
   color: var(--color-text);
   display: flex;
   flex-direction: column;
@@ -109,7 +100,7 @@
 .course-learn__pdf-preview__icon {
   width: 64px;
   height: 64px;
-  color: var(--brand);
+  color: var(--color-brand);
   margin-bottom: 12px;
 }
 
@@ -121,13 +112,13 @@
 }
 
 .course-learn__pdf-preview__desc {
-  color: var(--muted);
+  color: var(--color-text-muted);
   margin-bottom: 12px;
 }
 
 .course-learn__brand-btn {
-  background: var(--brand);
-  color: var(--brand-foreground);
+  background: var(--color-brand);
+  color: var(--color-text-light);
   border: none;
   padding: 8px 14px;
   border-radius: 6px;
@@ -138,8 +129,8 @@
 }
 
 .course-learn__info-card {
-  background: var(--card-bg);
-  border: 1px solid var(--border);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   padding: 16px;
 }
@@ -159,8 +150,8 @@
 
 .course-learn__aside {
   width: 100%;
-  border-top: 1px solid var(--border);
-  background: var(--card-bg);
+  border-top: 1px solid var(--color-border);
+  background: var(--color-surface);
 }
 
 @media (min-width: 1024px) {
@@ -173,7 +164,7 @@
 
 .course-learn__curriculum {
   padding: 12px;
-  border-bottom: 1px solid var(--border);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .course-learn__curriculum__title {
@@ -183,7 +174,7 @@
 
 .course-learn__curriculum__meta {
   font-size: var(--text-sm);
-  color: var(--muted);
+  color: var(--color-text-muted);
 }
 
 .course-learn__curriculum__list {
@@ -216,7 +207,7 @@
 
 .course-learn__section-meta {
   font-size: 0.75rem;
-  color: var(--muted);
+  color: var(--color-text-muted);
 }
 
 .course-learn__section-content {
@@ -245,7 +236,7 @@
 .course-learn__lecture-icon {
   width: 20px;
   height: 20px;
-  color: var(--muted);
+  color: var(--color-text-muted);
 }
 
 .course-learn__lecture-text {
@@ -262,6 +253,6 @@
 
 .course-learn__lecture-meta {
   font-size: 0.75rem;
-  color: var(--muted);
+  color: var(--color-text-muted);
 }
 

--- a/src/app/courses/[id]/learn/CourseLearnPage.module.css
+++ b/src/app/courses/[id]/learn/CourseLearnPage.module.css
@@ -1,0 +1,267 @@
+:root {
+  /* use global design tokens where possible */
+  --brand: var(--color-brand);
+  --brand-foreground: var(--color-text-light);
+  --muted: var(--color-text-muted);
+  --card-bg: var(--color-surface);
+  --bg: var(--color-bg);
+  --border: var(--color-border);
+  --accent: rgba(239,104,23,0.08); /* subtle brand tint */
+}
+
+.course-learn {
+  min-height: 100vh;
+  background: var(--bg);
+  color: var(--color-text);
+  display: flex;
+  flex-direction: column;
+}
+
+.course-learn__header {
+  border-bottom: 1px solid var(--border);
+  background: var(--card-bg);
+}
+
+.course-learn__header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 16px;
+}
+
+.course-learn__header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.course-learn__back-btn {
+  background: transparent;
+  border: none;
+  padding: 6px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+
+.course-learn__icon {
+  width: 20px;
+  height: 20px;
+  color: var(--color-text-muted);
+}
+
+.course-learn__title {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.course-learn__progress {
+  font-size: var(--text-sm);
+  color: var(--muted);
+}
+
+.course-learn__layout {
+  display: flex;
+  flex-direction: column;
+}
+
+@media (min-width: 1024px) {
+  .course-learn__layout {
+    flex-direction: row;
+  }
+}
+
+.course-learn__main {
+  flex: 1;
+  padding: 16px;
+}
+
+.course-learn__player-wrap {
+  margin-bottom: 24px;
+}
+
+.course-learn__player {
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: #000;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.course-learn__video {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+
+.course-learn__pdf-preview {
+  width: 100%;
+  aspect-ratio: 16/9;
+  background: var(--card-bg);
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+}
+
+.course-learn__pdf-preview__icon {
+  width: 64px;
+  height: 64px;
+  color: var(--brand);
+  margin-bottom: 12px;
+}
+
+.course-learn__pdf-preview__title {
+  font-size: var(--text-lg);
+  font-weight: 600;
+  color: var(--color-text);
+  margin-bottom: 6px;
+}
+
+.course-learn__pdf-preview__desc {
+  color: var(--muted);
+  margin-bottom: 12px;
+}
+
+.course-learn__brand-btn {
+  background: var(--brand);
+  color: var(--brand-foreground);
+  border: none;
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.course-learn__info-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 16px;
+}
+
+.course-learn__info-row {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.course-learn__info-title {
+  font-size: var(--text-lg);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.course-learn__aside {
+  width: 100%;
+  border-top: 1px solid var(--border);
+  background: var(--card-bg);
+}
+
+@media (min-width: 1024px) {
+  .course-learn__aside {
+    width: 380px;
+    border-left: 1px solid var(--border);
+    border-top: none;
+  }
+}
+
+.course-learn__curriculum {
+  padding: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.course-learn__curriculum__title {
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.course-learn__curriculum__meta {
+  font-size: var(--text-sm);
+  color: var(--muted);
+}
+
+.course-learn__curriculum__list {
+  max-height: calc(100vh - 200px);
+  overflow-y: auto;
+  padding: 8px;
+}
+
+.course-learn__section-btn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.course-learn__section-info {
+  display: flex;
+  flex-direction: column;
+}
+
+.course-learn__section-title {
+  font-weight: 600;
+  color: var(--color-text);
+}
+
+.course-learn__section-meta {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.course-learn__section-content {
+  margin-left: 10px;
+  padding-left: 10px;
+  border-left: 1px solid var(--border);
+}
+
+.course-learn__lecture-btn {
+  width: 100%;
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  padding: 12px;
+  border-radius: 8px;
+  background: transparent;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+}
+
+.course-learn__lecture-btn--active {
+  background: var(--accent);
+}
+
+.course-learn__lecture-icon {
+  width: 20px;
+  height: 20px;
+  color: var(--muted);
+}
+
+.course-learn__lecture-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.course-learn__lecture-title {
+  font-size: 0.95rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.course-learn__lecture-meta {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+

--- a/src/app/courses/[id]/learn/CourseLearnPage.module.css
+++ b/src/app/courses/[id]/learn/CourseLearnPage.module.css
@@ -1,5 +1,4 @@
 .course-learn {
-  /* use global tokens from src/app/global.css; only define local accent */
   --accent: rgba(239,104,23,0.08);
   min-height: 100vh;
   background: var(--color-bg);

--- a/src/app/courses/[id]/learn/page.tsx
+++ b/src/app/courses/[id]/learn/page.tsx
@@ -1,7 +1,6 @@
 import CourseLearnClient from '@/domains/course/pages/CourseLearnClientPage';
 
 export default function CourseLearnPage() {
-  // Server component: render client component for interactive UI
   return (
     <CourseLearnClient />
   );

--- a/src/app/courses/[id]/learn/page.tsx
+++ b/src/app/courses/[id]/learn/page.tsx
@@ -1,3 +1,8 @@
+import CourseLearnClient from '@/domains/course/pages/CourseLearnClientPage';
+
 export default function CourseLearnPage() {
-  return <div></div>;
+  // Server component: render client component for interactive UI
+  return (
+    <CourseLearnClient />
+  );
 }

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ChevronDown, ChevronRight, Play, FileText, Download, CheckCircle, ArrowLeft } from "lucide-react";
+import styles from '@/app/courses/[id]/learn/CourseLearnPage.module.css';
+
+
+type Lecture = {
+  id: string;
+  title: string;
+  type: "video" | "pdf";
+  duration?: string;
+  description: string;
+  completed: boolean;
+  videoUrl?: string;
+  pdfUrl?: string;
+};
+
+type Section = {
+  id: string;
+  title: string;
+  description: string;
+  lectures: Lecture[];
+};
+
+type Course = {
+  id: string;
+  title: string;
+  instructor: string;
+  description: string;
+  sections: Section[];
+};
+
+// 더미 데이터
+const courseData: Course = {
+  id: "1",
+  title: "에헴",
+  instructor: "lee2 강사",
+  description: "테스트 입니다",
+  sections: [
+    {
+      id: "s1",
+      title: "섹션 1: 시작하기",
+      description: "강좌의 기본적인 내용을 소개합니다.",
+      lectures: [
+        {
+          id: "l1",
+          title: "강좌 소개",
+          type: "video",
+          duration: "10:30",
+          description: "이 강좌에서 배울 내용에 대해 알아봅니다.",
+          completed: true,
+          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        },
+        {
+          id: "l2",
+          title: "학습 자료 다운로드",
+          type: "pdf",
+          description: "강좌에서 사용할 학습 자료입니다.",
+          completed: false,
+          pdfUrl: "/sample.pdf",
+        },
+      ],
+    },
+    {
+      id: "s2",
+      title: "섹션 2: 기초 개념",
+      description: "핵심 개념들을 학습합니다.",
+      lectures: [
+        {
+          id: "l3",
+          title: "기초 개념 1",
+          type: "video",
+          duration: "15:20",
+          description: "첫 번째 기초 개념에 대해 배웁니다.",
+          completed: false,
+          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        },
+        {
+          id: "l4",
+          title: "기초 개념 2",
+          type: "video",
+          duration: "12:45",
+          description: "두 번째 기초 개념에 대해 배웁니다.",
+          completed: false,
+          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        },
+        {
+          id: "l5",
+          title: "기초 개념 정리 자료",
+          type: "pdf",
+          description: "기초 개념을 정리한 PDF 자료입니다.",
+          completed: false,
+          pdfUrl: "/sample.pdf",
+        },
+      ],
+    },
+    {
+      id: "s3",
+      title: "섹션 3: 심화 학습",
+      description: "더 깊은 내용을 학습합니다.",
+      lectures: [
+        {
+          id: "l6",
+          title: "심화 주제 1",
+          type: "video",
+          duration: "20:00",
+          description: "심화 주제에 대해 학습합니다.",
+          completed: false,
+          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
+        },
+      ],
+    },
+  ],
+};
+
+export default function CourseLearnPage() {
+  const [currentLecture, setCurrentLecture] = useState<Lecture>(courseData.sections[0].lectures[0]);
+  const [openSections, setOpenSections] = useState<string[]>(["s1"]);
+
+  const toggleSection = (sectionId: string) => {
+    setOpenSections((prev) => (prev.includes(sectionId) ? prev.filter((id) => id !== sectionId) : [...prev, sectionId]));
+  };
+
+  const handleLectureClick = (lecture: Lecture) => {
+    setCurrentLecture(lecture);
+  };
+
+  const getTotalLectures = () => {
+    return courseData.sections.reduce((acc, section) => acc + section.lectures.length, 0);
+  };
+
+  const getCompletedLectures = () => {
+    return courseData.sections.reduce((acc, section) => acc + section.lectures.filter((l) => l.completed).length, 0);
+  };
+
+  return (
+    <div className={styles['course-learn']}>
+      {/* 헤더 */}
+      <header className={styles['course-learn__header']}>
+        <div className={styles['course-learn__header-inner']}>
+          <div className={styles['course-learn__header-left']}>
+            <Link href="/">
+              <button className={styles['course-learn__back-btn']} aria-label="back">
+                <ArrowLeft className={styles['course-learn__icon']} />
+              </button>
+            </Link>
+            <h1 className={styles['course-learn__title']}>{courseData.title}</h1>
+          </div>
+          <div className={styles['course-learn__progress']}>
+            진도율: {getCompletedLectures()}/{getTotalLectures()} 완료
+          </div>
+        </div>
+      </header>
+
+      <div className={styles['course-learn__layout']}>
+        {/* 메인 컨텐츠 영역 */}
+        <main className={styles['course-learn__main']}>
+          {/* 비디오/PDF 플레이어 */}
+          <div className={styles['course-learn__player-wrap']}>
+            {currentLecture.type === "video" ? (
+              <div className={styles['course-learn__player']}>
+                <video key={currentLecture.id} className={styles['course-learn__video']} controls autoPlay>
+                  <source src={currentLecture.videoUrl} type="video/mp4" />
+                  브라우저가 비디오를 지원하지 않습니다.
+                </video>
+              </div>
+            ) : (
+              <div className={styles['course-learn__pdf-preview']}>
+                <FileText className={styles['course-learn__pdf-preview__icon']} />
+                <h3 className={styles['course-learn__pdf-preview__title']}>{currentLecture.title}</h3>
+                <p className={styles['course-learn__pdf-preview__desc']}>{currentLecture.description}</p>
+                <a href={currentLecture.pdfUrl} download>
+                  <button className={styles['course-learn__brand-btn']}>
+                    <Download className={styles['course-learn__icon']} />
+                    PDF 다운로드
+                  </button>
+                </a>
+              </div>
+            )}
+          </div>
+
+          {/* 현재 강의 정보 */}
+          <div className={styles['course-learn__info-card']}>
+            <div className={styles['course-learn__info-row']}>
+              {currentLecture.type === "video" ? <Play className={styles['course-learn__icon']} /> : <FileText className={styles['course-learn__icon']} />}
+              <span className={styles['course-learn__progress']}>
+                {currentLecture.type === "video" ? "영상 강의" : "PDF 자료"}
+                {currentLecture.duration && ` · ${currentLecture.duration}`}
+              </span>
+            </div>
+            <h2 className={styles['course-learn__info-title']}>{currentLecture.title}</h2>
+            <p className={styles['course-learn__pdf-preview__desc']}>{currentLecture.description}</p>
+          </div>
+        </main>
+
+        {/* 사이드바 - 커리큘럼 */}
+        <aside className={styles['course-learn__aside']}>
+          <div className={styles['course-learn__curriculum']}>
+            <h3 className={styles['course-learn__curriculum__title']}>커리큘럼</h3>
+            <p className={styles['course-learn__curriculum__meta']}>{getTotalLectures()}개 강의 · {getCompletedLectures()}개 완료</p>
+          </div>
+          <div className={styles['course-learn__curriculum__list']}>
+            {courseData.sections.map((section) => (
+              <div key={section.id}>
+                <button onClick={() => toggleSection(section.id)} className={styles['course-learn__section-btn']}>
+                  <div className={styles['course-learn__section-info']}>
+                    <h4 className={styles['course-learn__section-title']}>{section.title}</h4>
+                    <p className={styles['course-learn__section-meta']}>{section.lectures.length}개 강의</p>
+                  </div>
+                  {openSections.includes(section.id) ? <ChevronDown className={styles['course-learn__icon']} /> : <ChevronRight className={styles['course-learn__icon']} />}
+                </button>
+                {openSections.includes(section.id) && (
+                  <div className={styles['course-learn__section-content']}>
+                    {section.lectures.map((lecture) => (
+                      <button key={lecture.id} onClick={() => handleLectureClick(lecture)} className={`${styles['course-learn__lecture-btn']} ${currentLecture.id === lecture.id ? styles['course-learn__lecture-btn--active'] : ""}`}>
+                        <div className={styles['course-learn__lecture-icon']}>
+                          {lecture.completed ? <CheckCircle className={styles['course-learn__icon']} /> : lecture.type === "video" ? <Play className={styles['course-learn__icon']} /> : <FileText className={styles['course-learn__icon']} />}
+                        </div>
+                        <div className={styles['course-learn__lecture-text']}>
+                          <p className={styles['course-learn__lecture-title']}>{lecture.title}</p>
+                          <p className={styles['course-learn__lecture-meta']}>{lecture.type === "video" ? lecture.duration : "PDF"}</p>
+                        </div>
+                      </button>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </aside>
+      </div>
+    </div>
+  );
+}

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -4,9 +4,9 @@ import { useState } from "react";
 import Link from "next/link";
 import { ChevronDown, ChevronRight, Play, FileText, Download, CheckCircle, ArrowLeft } from "lucide-react";
 import styles from '@/app/courses/[id]/learn/CourseLearnPage.module.css';
+import type { CourseDetailResponse } from '@/domains/course/types/course';
 
-
-type Lecture = {
+type UILecture = {
   id: string;
   title: string;
   type: "video" | "pdf";
@@ -17,113 +17,108 @@ type Lecture = {
   pdfUrl?: string;
 };
 
-type Section = {
+type UISection = {
   id: string;
   title: string;
   description: string;
-  lectures: Lecture[];
+  lectures: UILecture[];
 };
 
-type Course = {
+type UICourse = {
   id: string;
   title: string;
   instructor: string;
   description: string;
-  sections: Section[];
+  sections: UISection[];
 };
 
-// 더미 데이터
-const courseData: Course = {
-  id: "1",
-  title: "에헴",
-  instructor: "lee2 강사",
-  description: "테스트 입니다",
+const dummyCourseDetail: CourseDetailResponse = {
+  course: {
+    id: '1',
+    title: '에헴',
+    summary: '테스트 요약',
+    description: '테스트 입니다',
+    thumbnailUrl: '/thumb.jpg',
+    instructorId: 'instr1',
+    instructorName: 'lee2 강사',
+    category: ['programming'],
+    level: 'beginner',
+    tags: ['test'],
+    price: 0,
+    isFree: true,
+    studentCount: 123,
+    duration: 3600,
+    status: 'published',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    sections: ['s1', 's2', 's3'],
+  },
   sections: [
-    {
-      id: "s1",
-      title: "섹션 1: 시작하기",
-      description: "강좌의 기본적인 내용을 소개합니다.",
-      lectures: [
-        {
-          id: "l1",
-          title: "강좌 소개",
-          type: "video",
-          duration: "10:30",
-          description: "이 강좌에서 배울 내용에 대해 알아봅니다.",
-          completed: true,
-          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
-        },
-        {
-          id: "l2",
-          title: "학습 자료 다운로드",
-          type: "pdf",
-          description: "강좌에서 사용할 학습 자료입니다.",
-          completed: false,
-          pdfUrl: "/sample.pdf",
-        },
-      ],
-    },
-    {
-      id: "s2",
-      title: "섹션 2: 기초 개념",
-      description: "핵심 개념들을 학습합니다.",
-      lectures: [
-        {
-          id: "l3",
-          title: "기초 개념 1",
-          type: "video",
-          duration: "15:20",
-          description: "첫 번째 기초 개념에 대해 배웁니다.",
-          completed: false,
-          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
-        },
-        {
-          id: "l4",
-          title: "기초 개념 2",
-          type: "video",
-          duration: "12:45",
-          description: "두 번째 기초 개념에 대해 배웁니다.",
-          completed: false,
-          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
-        },
-        {
-          id: "l5",
-          title: "기초 개념 정리 자료",
-          type: "pdf",
-          description: "기초 개념을 정리한 PDF 자료입니다.",
-          completed: false,
-          pdfUrl: "/sample.pdf",
-        },
-      ],
-    },
-    {
-      id: "s3",
-      title: "섹션 3: 심화 학습",
-      description: "더 깊은 내용을 학습합니다.",
-      lectures: [
-        {
-          id: "l6",
-          title: "심화 주제 1",
-          type: "video",
-          duration: "20:00",
-          description: "심화 주제에 대해 학습합니다.",
-          completed: false,
-          videoUrl: "https://www.w3schools.com/html/mov_bbb.mp4",
-        },
-      ],
-    },
+    { id: 's1', courseId: '1', title: '섹션 1: 시작하기', sequence: 1, lectures: ['l1', 'l2'], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    { id: 's2', courseId: '1', title: '섹션 2: 기초 개념', sequence: 2, lectures: ['l3', 'l4', 'l5'], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    { id: 's3', courseId: '1', title: '섹션 3: 심화 학습', sequence: 3, lectures: ['l6'], createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
   ],
+  lectures: {
+    s1: [
+      { id: 'l1', sectionId: 's1', courseId: '1', title: '강좌 소개', videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4', duration: 630, sequence: 1, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 'l2', sectionId: 's1', courseId: '1', title: '학습 자료 다운로드', videoUrl: '', duration: 0, sequence: 2, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ],
+    s2: [
+      { id: 'l3', sectionId: 's2', courseId: '1', title: '기초 개념 1', videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4', duration: 920, sequence: 1, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 'l4', sectionId: 's2', courseId: '1', title: '기초 개념 2', videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4', duration: 765, sequence: 2, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+      { id: 'l5', sectionId: 's2', courseId: '1', title: '기초 개념 정리 자료', videoUrl: '', duration: 0, sequence: 3, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ],
+    s3: [
+      { id: 'l6', sectionId: 's3', courseId: '1', title: '심화 주제 1', videoUrl: 'https://www.w3schools.com/html/mov_bbb.mp4', duration: 1200, sequence: 1, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() },
+    ],
+  },
 };
+
+function formatDurationSeconds(seconds: number) {
+  if (!seconds || seconds <= 0) return undefined;
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+}
+
+function buildUICourseFromDetail(detail: CourseDetailResponse): UICourse {
+  const course = detail.course;
+  const sections = detail.sections.map((sec) => ({
+    id: sec.id,
+    title: sec.title,
+    description: '',
+    lectures: (detail.lectures[sec.id] || []).map((lec) => ({
+      id: lec.id,
+      title: lec.title,
+      type: (lec.videoUrl ? 'video' : 'pdf') as 'video' | 'pdf',
+      duration: lec.duration ? formatDurationSeconds(lec.duration) : undefined,
+      description: '',
+      completed: false,
+      videoUrl: lec.videoUrl || undefined,
+      pdfUrl: lec.videoUrl ? undefined : '/sample.pdf',
+    })),
+  }));
+
+  return {
+    id: course?.id ?? '0',
+    title: course?.title ?? '',
+    instructor: course?.instructorName ?? '',
+    description: course?.description ?? '',
+    sections,
+  };
+}
+
+const courseData: UICourse = buildUICourseFromDetail(dummyCourseDetail);
 
 export default function CourseLearnPage() {
-  const [currentLecture, setCurrentLecture] = useState<Lecture>(courseData.sections[0].lectures[0]);
+  const [currentLecture, setCurrentLecture] = useState<UILecture>(courseData.sections[0].lectures[0]);
   const [openSections, setOpenSections] = useState<string[]>(["s1"]);
 
   const toggleSection = (sectionId: string) => {
     setOpenSections((prev) => (prev.includes(sectionId) ? prev.filter((id) => id !== sectionId) : [...prev, sectionId]));
   };
 
-  const handleLectureClick = (lecture: Lecture) => {
+  const handleLectureClick = (lecture: UILecture) => {
     setCurrentLecture(lecture);
   };
 


### PR DESCRIPTION
## 구현 내용
- App Router 경로 `/courses/[id]/learn`에 강좌 학습(시청) 페이지 추가
- 좌측(또는 상단)에 동영상 플레이어, 우측(또는 하단)에 강의(섹션/레슨) 목록이 보이는 2단 레이아웃 UI 구성
- 현재 학습 중인 레슨의 제목, 간단 소개, 진행률 등 기본 정보 영역 마크업
- 강의 목록에서 현재 학습 중인 레슨을 하이라이트 처리하는 스타일 적용
- 백엔드 연동 전까지 더미 데이터 기반으로 UI 동작하도록 임시 연결
- 기존 강좌 도메인 페이지와 톤을 맞추기 위해 글로벌 스타일/레이아웃 토큰 재사용

## 테스트 방법
1. 로컬에서 앱 실행 후 `/courses/{테스트용 id}/learn` 경로로 접속한다.
2. 데스크톱 사이즈에서 플레이어 영역과 강의 목록이 의도한 2단 레이아웃으로 보이는지 확인한다.
3. 강의 목록에서 다른 레슨을 클릭했을 때, 현재 학습 중인 레슨 하이라이트가 변경되는지 확인한다.
4. 브라우저 너비를 줄여 모바일 사이즈에서 플레이어/목록 순서와 레이아웃이 깨지지 않는지 확인한다.

## 확인 요청 사항
- `/courses/[id]/learn` 라우트 경로 네이밍이 도메인 설계와 맞는지
- 페이지에서 노출 중인 정보(제목, 설명, 진행률 등)의 우선순위와 구성 방식이 기획 의도와 맞는지

close #61
