### PR TITLE
feat: 강의 재생 정보 영역 duration을 mm:ss로 포맷팅

### DIFF
--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -37,7 +37,6 @@ async function getMyEnrollmentId(courseId: string): Promise<string | null> {
 export function useCourseLearn() {
   const { id: courseIdParam } = useParams();
   const courseId = String(courseIdParam);
-
   const [learnData, setLearnData] = useState<CourseLearn | null>(null);
 
   useEffect(() => {
@@ -93,6 +92,22 @@ export function useCourseLearn() {
   const toggleSection = (id: string) => {
     setOpenSections((prev) => (prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id]));
   };
+
+  useEffect(() => {
+    if (!courseData || !currentLecture) return;
+
+    const currentSection = courseData.sections.find((section) =>
+      section.lectures.some((lecture) => lecture.id === currentLecture.id),
+    );
+
+    if (!currentSection) return;
+
+    setOpenSections((prev) => {
+      if (prev.includes(currentSection.id)) return prev;
+      //return [currentSection.id];
+      return courseData.sections.map((s) => s.id);
+    });
+  }, [courseData, currentLecture]);
 
   /** 강의 클릭 */
   const handleLectureClick = (lec: ProcessedLecture) => {

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -13,6 +13,7 @@ import {
   CheckCircle,
 } from 'lucide-react';
 import { useRouter } from 'next/navigation';
+import { formatLectureDuration } from '@/domains/course/utils/formatDuration';
 
 export default function CourseLearnClient() {
   const router = useRouter();
@@ -100,7 +101,7 @@ export default function CourseLearnClient() {
               )}
               <span className={styles['course-learn__progress']}>
                 {currentLecture.type === 'VIDEO' ? '영상 강의' : 'PDF 자료'}
-                {currentLecture.duration && ` · ${currentLecture.duration}`}
+                {currentLecture.duration && ` · ${formatLectureDuration(currentLecture.duration)}`}
               </span>
             </div>
             <h2 className={styles['course-learn__info-title']}>{currentLecture.title}</h2>
@@ -161,7 +162,9 @@ export default function CourseLearnClient() {
                         <div className={styles['course-learn__lecture-text']}>
                           <p className={styles['course-learn__lecture-title']}>{lecture.title}</p>
                           <p className={styles['course-learn__lecture-meta']}>
-                            {lecture.type === 'VIDEO' ? lecture.duration : 'PDF'}
+                            {lecture.type === 'VIDEO'
+                              ? formatLectureDuration(lecture.duration)
+                              : 'PDF'}
                           </p>
                         </div>
                       </button>

--- a/src/domains/course/utils/formatDuration.ts
+++ b/src/domains/course/utils/formatDuration.ts
@@ -8,3 +8,13 @@ export const formatDuration = (totalMinutes: number): string => {
   if (minutes === 0) return `${hours}시간`;
   return `${hours}시간 ${minutes}분`;
 };
+
+/** 강의 재생용 (초 단위 → mm:ss) */
+export const formatLectureDuration = (totalSeconds: number): string => {
+  if (!totalSeconds || totalSeconds <= 0) return '00:00';
+
+  const m = Math.floor(totalSeconds / 60);
+  const s = totalSeconds % 60;
+
+  return `${String(m).padStart(2, '0')}:${String(s).padStart(2, '0')}`;
+};


### PR DESCRIPTION
## 변경 사항

- 강의 시청 페이지에서 영상 강의 duration을 mm:ss 형식으로 표시하도록 개선
- 커리큘럼 섹션을 자동으로 펼치도록 UX 개선
- 강의 / 강좌 시간 표기를 분리하기 위한 course 도메인 유틸 추가

## 리뷰 필요

- 강의 시청 페이지 진입
- 첫 강의가 자동 선택되며 섹션들이 자동으로 펼쳐져있는지 확인
- 다른 섹션의 강의 클릭 시 해당 섹션이 토글 형태로 작동하는지 확인
- 영상 강의 duration이 mm:ss 형식으로 표시되는지 확인
- PDF 강의는 duration 대신 PDF로 표시되는지 확인

close #77 
