### PR TITLE
feat: 서비스명 변경에 따른 로고 및 배너 텍스트 수정

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -6,7 +6,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
     <div className={styles['auth-shell']}>
       <header className={styles['auth-shell__header']} role="banner" aria-label="인증 헤더">
         <Link href="/" className={styles['auth-shell__brand']}>
-          LearNix
+          Learnix
         </Link>
       </header>
 
@@ -18,7 +18,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
 
       <footer className={styles['auth-shell__footer']} role="contentinfo">
         <p className={styles['auth-shell__footer-text']}>
-          도움이 필요하신가요? support@LearNix.example
+          도움이 필요하신가요? support@learnix.example
         </p>
       </footer>
     </div>

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -6,7 +6,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
     <div className={styles['auth-shell']}>
       <header className={styles['auth-shell__header']} role="banner" aria-label="인증 헤더">
         <Link href="/" className={styles['auth-shell__brand']}>
-          LernP
+          LearNix
         </Link>
       </header>
 
@@ -18,7 +18,7 @@ export default function AuthLayout({ children }: { children: React.ReactNode }) 
 
       <footer className={styles['auth-shell__footer']} role="contentinfo">
         <p className={styles['auth-shell__footer-text']}>
-          도움이 필요하신가요? support@lernp.example
+          도움이 필요하신가요? support@LearNix.example
         </p>
       </footer>
     </div>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ import { AuthProvider } from './_providers/AuthProvider';
 // }
 
 export const metadata: Metadata = {
-  title: 'LernP ',
+  title: 'LearNix',
   description: '역할 전환형 온라인 학습 플랫폼',
 };
 

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,7 +12,7 @@ import { AuthProvider } from './_providers/AuthProvider';
 // }
 
 export const metadata: Metadata = {
-  title: 'LearNix',
+  title: 'Learnix',
   description: '역할 전환형 온라인 학습 플랫폼',
 };
 

--- a/src/domains/course/pages/CourseListClientPage.tsx
+++ b/src/domains/course/pages/CourseListClientPage.tsx
@@ -52,7 +52,7 @@ export default function CourseListClientPage() {
       <div className={styles['bannerContainer']}>
         <div className={styles['bannerContent']}>
           <div className={styles['mainText']}>
-            강사, 학생 둘 다 되는 게 <span className={styles['highlightText']}>런피</span>
+            강사, 학생 둘 다 되는 게 <span className={styles['highlightText']}>런닉스</span>
           </div>
           <div className={styles['subText']}>한 번의 클릭으로 배움과 가르침을 모두 경험하세요</div>
         </div>

--- a/src/shared/ui/AppShell.tsx
+++ b/src/shared/ui/AppShell.tsx
@@ -9,7 +9,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         {children}
       </main>
       <footer className={styles['app-shell__footer']} role="contentinfo">
-        <p className={styles['app-shell__footer-text']}>© {new Date().getFullYear()} LearNix</p>
+        <p className={styles['app-shell__footer-text']}>© {new Date().getFullYear()} Learnix</p>
       </footer>
     </div>
   );

--- a/src/shared/ui/AppShell.tsx
+++ b/src/shared/ui/AppShell.tsx
@@ -9,7 +9,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         {children}
       </main>
       <footer className={styles['app-shell__footer']} role="contentinfo">
-        <p className={styles['app-shell__footer-text']}>© {new Date().getFullYear()} LernP</p>
+        <p className={styles['app-shell__footer-text']}>© {new Date().getFullYear()} LearNix</p>
       </footer>
     </div>
   );

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -69,7 +69,7 @@ export function Header() {
           {/* 왼쪽: 로고 */}
           <div className={styles['header__left']}>
             <Link href="/" className={styles['header__logo']} aria-label="홈으로 이동">
-              <span className={styles['header__logo-text']}>LernP</span>
+              <span className={styles['header__logo-text']}>LearNix</span>
             </Link>
           </div>
 

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -69,7 +69,7 @@ export function Header() {
           {/* 왼쪽: 로고 */}
           <div className={styles['header__left']}>
             <Link href="/" className={styles['header__logo']} aria-label="홈으로 이동">
-              <span className={styles['header__logo-text']}>LearNix</span>
+              <span className={styles['header__logo-text']}>Learnix</span>
             </Link>
           </div>
 


### PR DESCRIPTION
## 변경 내용
- 서비스명 변경에 따라 공통 레이아웃 및 헤더 로고 텍스트 수정
- 메인 배너 영역에 노출되는 서비스명 텍스트 수정

## 작업 범위
- layout.tsx (app)
- layout.tsx (courses)
- Header.tsx
- AppShell.tsx
- CourseListClientPage.tsx

## 확인 사항
- 서비스명 노출 영역 정상 반영 여부 확인
- 레이아웃 및 스타일 변경 없음

close #79 
