### PR TITLE
refactor: 강좌 등록 버튼 클릭 시 강좌 데이터 전체 로그 출력

### DIFF
--- a/src/app/_providers/AuthProvider.tsx
+++ b/src/app/_providers/AuthProvider.tsx
@@ -22,6 +22,8 @@ const DEV_FAKE_USER: User = {
   updatedAt: new Date(),
 };
 
+sessionStorage.setItem('draftCourseId', 'DEV_COURSE_ID');
+
 export function AuthProvider({ initialUser, children }: AuthProviderProps) {
   const setUser = useUserStore((s) => s.setUser);
   const resetUser = useUserStore((s) => s.clearUser);

--- a/src/app/_providers/AuthProvider.tsx
+++ b/src/app/_providers/AuthProvider.tsx
@@ -9,6 +9,19 @@ type AuthProviderProps = {
   children: React.ReactNode;
 };
 
+const DEV_FAKE_USER: User = {
+  id: 'DEV_USER_ID',
+  email: 'dev-instructor@test.com',
+  nickname: '개발용강사',
+  roles: ['INSTRUCTOR'],
+  cart: [],
+  enrolledCourses: [],
+  createdCourses: [],
+  avatarUrl: undefined,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
 export function AuthProvider({ initialUser, children }: AuthProviderProps) {
   const setUser = useUserStore((s) => s.setUser);
   const resetUser = useUserStore((s) => s.clearUser);
@@ -19,8 +32,12 @@ export function AuthProvider({ initialUser, children }: AuthProviderProps) {
     // 서버에서 받은 initialUser를 zustand에 싱크
     setIsLoading(true);
 
+    const isDev = process.env.NODE_ENV === 'development';
+
     if (initialUser) {
       setUser(initialUser);
+    } else if (isDev) {
+      setUser(DEV_FAKE_USER);
     } else {
       resetUser();
     }

--- a/src/app/_providers/AuthProvider.tsx
+++ b/src/app/_providers/AuthProvider.tsx
@@ -9,21 +9,6 @@ type AuthProviderProps = {
   children: React.ReactNode;
 };
 
-const DEV_FAKE_USER: User = {
-  id: 'DEV_USER_ID',
-  email: 'dev-instructor@test.com',
-  nickname: '개발용강사',
-  roles: ['INSTRUCTOR'],
-  cart: [],
-  enrolledCourses: [],
-  createdCourses: [],
-  avatarUrl: undefined,
-  createdAt: new Date(),
-  updatedAt: new Date(),
-};
-
-sessionStorage.setItem('draftCourseId', 'DEV_COURSE_ID');
-
 export function AuthProvider({ initialUser, children }: AuthProviderProps) {
   const setUser = useUserStore((s) => s.setUser);
   const resetUser = useUserStore((s) => s.clearUser);
@@ -33,6 +18,19 @@ export function AuthProvider({ initialUser, children }: AuthProviderProps) {
   useEffect(() => {
     // 서버에서 받은 initialUser를 zustand에 싱크
     setIsLoading(true);
+
+    const DEV_FAKE_USER: User = {
+      id: 'DEV_USER_ID',
+      email: 'dev-instructor@test.com',
+      nickname: '개발용강사',
+      roles: ['INSTRUCTOR'],
+      cart: [],
+      enrolledCourses: [],
+      createdCourses: [],
+      avatarUrl: undefined,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    };
 
     const isDev = process.env.NODE_ENV === 'development';
 

--- a/src/app/_providers/AuthProvider.tsx
+++ b/src/app/_providers/AuthProvider.tsx
@@ -19,25 +19,8 @@ export function AuthProvider({ initialUser, children }: AuthProviderProps) {
     // 서버에서 받은 initialUser를 zustand에 싱크
     setIsLoading(true);
 
-    const DEV_FAKE_USER: User = {
-      id: 'DEV_USER_ID',
-      email: 'dev-instructor@test.com',
-      nickname: '개발용강사',
-      roles: ['INSTRUCTOR'],
-      cart: [],
-      enrolledCourses: [],
-      createdCourses: [],
-      avatarUrl: undefined,
-      createdAt: new Date(),
-      updatedAt: new Date(),
-    };
-
-    const isDev = process.env.NODE_ENV === 'development';
-
     if (initialUser) {
       setUser(initialUser);
-    } else if (isDev) {
-      setUser(DEV_FAKE_USER);
     } else {
       resetUser();
     }

--- a/src/domains/course/components/CourseForm.tsx
+++ b/src/domains/course/components/CourseForm.tsx
@@ -19,6 +19,7 @@ export function CourseForm() {
     handleCategoryChange,
     handleThumbnailUpload,
     handleThumbnailFileSelect,
+    handleCancel,
   } = useCourseForm();
 
   return (
@@ -139,7 +140,7 @@ export function CourseForm() {
         <button
           type="button"
           className={`${styles['btn']} ${styles['btn--ghost']}`}
-          onClick={() => router.back()}
+          onClick={() => handleCancel()}
         >
           취소
         </button>

--- a/src/domains/course/components/SectionForm.tsx
+++ b/src/domains/course/components/SectionForm.tsx
@@ -10,7 +10,7 @@ export function SectionForm() {
   const router = useRouter();
   const {
     sections,
-    step1Data,
+    // step1Data,
     loading,
     submitting,
     error,
@@ -27,9 +27,9 @@ export function SectionForm() {
     handlePrevStep,
   } = useSectionForm();
 
-  if (!step1Data) {
-    return <p>강좌 기본 정보를 불러오는 중입니다. 잠시만 기다려주세요...</p>;
-  }
+  // if (!step1Data) {
+  //   return <p>강좌 기본 정보를 불러오는 중입니다. 잠시만 기다려주세요...</p>;
+  // }
   const savedCourseId =
     typeof window !== 'undefined' ? sessionStorage.getItem('draftCourseId') : null;
 

--- a/src/domains/course/components/SectionForm.tsx
+++ b/src/domains/course/components/SectionForm.tsx
@@ -30,13 +30,11 @@ export function SectionForm() {
   // if (!step1Data) {
   //   return <p>강좌 기본 정보를 불러오는 중입니다. 잠시만 기다려주세요...</p>;
   // }
-  const savedCourseId =
-    typeof window !== 'undefined' ? sessionStorage.getItem('draftCourseId') : null;
 
-  if (!savedCourseId) {
-    router.replace('/courses/create?step=1');
-    return;
-  }
+  // if (!savedCourseId) {
+  //   router.replace('/courses/create?step=1');
+  //   return;
+  // }
 
   return (
     <form onSubmit={handleFinalSubmit}>

--- a/src/domains/course/components/SectionForm.tsx
+++ b/src/domains/course/components/SectionForm.tsx
@@ -25,6 +25,7 @@ export function SectionForm() {
     handleLectureUpload,
     handleFinalSubmit,
     handlePrevStep,
+    handleCancel,
   } = useSectionForm();
 
   // if (!step1Data) {
@@ -154,7 +155,7 @@ export function SectionForm() {
         <button
           type="button"
           className={`${styles['btn']} ${styles['btn--ghost']}`}
-          onClick={() => router.back()}
+          onClick={() => handleCancel()}
           disabled={loading}
         >
           취소

--- a/src/domains/course/components/SectionForm.tsx
+++ b/src/domains/course/components/SectionForm.tsx
@@ -10,7 +10,7 @@ export function SectionForm() {
   const router = useRouter();
   const {
     sections,
-    // step1Data,
+    step1Data,
     loading,
     submitting,
     error,
@@ -28,9 +28,9 @@ export function SectionForm() {
     handleCancel,
   } = useSectionForm();
 
-  // if (!step1Data) {
-  //   return <p>강좌 기본 정보를 불러오는 중입니다. 잠시만 기다려주세요...</p>;
-  // }
+  if (!step1Data) {
+    return <p>강좌 기본 정보를 불러오는 중입니다. 잠시만 기다려주세요...</p>;
+  }
 
   // if (!savedCourseId) {
   //   router.replace('/courses/create?step=1');

--- a/src/domains/course/hooks/useCourseCreateEntry.tsx
+++ b/src/domains/course/hooks/useCourseCreateEntry.tsx
@@ -1,0 +1,17 @@
+import { usePathname, useSearchParams, useRouter } from 'next/navigation';
+
+export function useCourseCreateEntry() {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const startCreateCourse = () => {
+    if (pathname.startsWith('/courses/create')) return;
+
+    const entry = pathname + (searchParams.toString() ? `?${searchParams.toString()}` : '');
+
+    router.push(`/courses/create?step=1&entry=${encodeURIComponent(entry)}`);
+  };
+
+  return { startCreateCourse };
+}

--- a/src/domains/course/hooks/useCourseForm.tsx
+++ b/src/domains/course/hooks/useCourseForm.tsx
@@ -15,10 +15,8 @@ export function useCourseForm() {
   const params = useParams<{ id?: string }>();
 
   const paramsId = typeof params.id === 'string' ? params.id : '';
-  const sessionCourseId =
-    typeof window !== 'undefined' ? (sessionStorage.getItem('draftCourseId') ?? '') : '';
 
-  const courseId = paramsId || sessionCourseId;
+  const courseId = paramsId;
 
   const [formData, setFormData] = useState<CourseFormState>({
     title: '',
@@ -95,7 +93,6 @@ export function useCourseForm() {
 
     if (process.env.NODE_ENV === 'development') {
       sessionStorage.setItem('courseDraft_step1', JSON.stringify(draftData));
-      sessionStorage.setItem('draftCourseId', 'DEV_COURSE_ID');
       router.push('/courses/create?step=2');
       return;
     }
@@ -111,10 +108,7 @@ export function useCourseForm() {
       // 2) 서버에 draft 강좌 생성 → courseId 확보
       const { courseId } = await createDraftCourse(draftData, thumbnailFile ?? undefined);
 
-      // 3) Step2에서 쓸 courseId 저장
-      sessionStorage.setItem('draftCourseId', String(courseId));
-
-      // 4) URL은 create 유지
+      // 3) URL은 create 유지
       router.push('/courses/create?step=2');
       return;
     } catch (err) {

--- a/src/domains/course/hooks/useCourseForm.tsx
+++ b/src/domains/course/hooks/useCourseForm.tsx
@@ -86,6 +86,20 @@ export function useCourseForm() {
 
     const draftData = buildCourseDraft(formData); // CourseDraftForm
 
+    console.log('[COURSE PUBLISH]', {
+      courseId,
+      formData,
+      draftData,
+      thumbnailFile,
+    });
+
+    if (process.env.NODE_ENV === 'development') {
+      sessionStorage.setItem('courseDraft_step1', JSON.stringify(draftData));
+      sessionStorage.setItem('draftCourseId', 'DEV_COURSE_ID');
+      router.push('/courses/create?step=2');
+      return;
+    }
+
     try {
       try {
         sessionStorage.setItem('courseDraft_step1', JSON.stringify(draftData));

--- a/src/domains/course/hooks/useCourseForm.tsx
+++ b/src/domains/course/hooks/useCourseForm.tsx
@@ -86,19 +86,6 @@ export function useCourseForm() {
 
     const draftData = buildCourseDraft(formData); // CourseDraftForm
 
-    console.log('[COURSE PUBLISH]', {
-      courseId,
-      formData,
-      draftData,
-      thumbnailFile,
-    });
-
-    if (process.env.NODE_ENV === 'development') {
-      sessionStorage.setItem('courseDraft_step1', JSON.stringify(draftData));
-      goStep2();
-      return;
-    }
-
     try {
       try {
         sessionStorage.setItem('courseDraft_step1', JSON.stringify(draftData));

--- a/src/domains/course/hooks/useCourseForm.tsx
+++ b/src/domains/course/hooks/useCourseForm.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import { validateForm } from '@/shared/util/validateForm';
@@ -13,6 +13,8 @@ export function useCourseForm() {
   const router = useRouter();
   const { user } = useAuthState();
   const params = useParams<{ id?: string }>();
+  const searchParams = useSearchParams();
+  const entry = searchParams.get('entry');
 
   const paramsId = typeof params.id === 'string' ? params.id : '';
 
@@ -93,7 +95,7 @@ export function useCourseForm() {
 
     if (process.env.NODE_ENV === 'development') {
       sessionStorage.setItem('courseDraft_step1', JSON.stringify(draftData));
-      router.push('/courses/create?step=2');
+      goStep2();
       return;
     }
 
@@ -109,7 +111,7 @@ export function useCourseForm() {
       const { courseId } = await createDraftCourse(draftData, thumbnailFile ?? undefined);
 
       // 3) URL은 create 유지
-      router.push('/courses/create?step=2');
+      goStep2();
       return;
     } catch (err) {
       console.error(err);
@@ -117,6 +119,17 @@ export function useCourseForm() {
     } finally {
       setLoading(false);
     }
+  };
+
+  const goStep2 = () => {
+    const next = new URLSearchParams();
+    next.set('step', '2');
+    if (entry) next.set('entry', entry);
+    router.push(`/courses/create?${next.toString()}`);
+  };
+
+  const handleCancel = () => {
+    router.push(entry ? decodeURIComponent(entry) : '/');
   };
 
   // 카테고리 조회 + 초기 데이터 로드
@@ -181,5 +194,6 @@ export function useCourseForm() {
     handleCategoryChange,
     handleThumbnailUpload,
     handleThumbnailFileSelect,
+    handleCancel,
   };
 }

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -56,11 +56,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
       setResolvedCourseId(courseIdProp);
       return;
     }
-
-    if (typeof window !== 'undefined') {
-      const saved = sessionStorage.getItem('draftCourseId');
-      if (saved) setResolvedCourseId(saved);
-    }
   }, [params.id, courseIdProp]);
 
   const courseId = resolvedCourseId;
@@ -417,7 +412,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
       sessionStorage.removeItem('courseDraft_step1');
       sessionStorage.removeItem('courseDraft_step2');
       const devCourseId = courseId || 'DEV_COURSE_ID';
-      sessionStorage.setItem('draftCourseId', devCourseId);
       alert('개발 모드: 강좌가 완료된 것으로 처리합니다.');
       router.replace(`/courses/${devCourseId}`);
       return;

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -386,39 +386,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
   const handleFinalSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
-    if (process.env.NODE_ENV === 'development') {
-      console.group('[STEP2] Curriculum Draft');
-
-      sections.forEach((section, sIdx) => {
-        console.group(`Section ${sIdx + 1}: ${section.title}`);
-
-        section.lectures.forEach((lecture, lIdx) => {
-          console.log(`Lecture ${lIdx + 1}`, {
-            title: lecture.title,
-            duration: lecture.duration,
-            videoUrl: lecture.videoUrl,
-            isPreview: lecture.isPreview,
-            resources: lecture.resource.map((res) => ({
-              resourceType: res.resourceType,
-              fileUrl: res.fileUrl,
-              isDownloadable: res.isDownloadable,
-            })),
-          });
-        });
-
-        console.groupEnd();
-      });
-
-      console.groupEnd();
-
-      sessionStorage.removeItem('courseDraft_step1');
-      sessionStorage.removeItem('courseDraft_step2');
-      const devCourseId = courseId || 'DEV_COURSE_ID';
-      alert('개발 모드: 강좌가 완료된 것으로 처리합니다.');
-      router.replace(`/courses/${devCourseId}`);
-      return;
-    }
-
     if (submitting || drafting) return;
 
     if (!user) {

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -462,9 +462,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
   };
 
   const handlePrevStep = () => {
-    if (typeof window !== 'undefined') {
-      sessionStorage.setItem('courseDraft_step2', JSON.stringify(sections));
-    }
     const params = new URLSearchParams();
     params.set('step', '1');
     if (entry) params.set('entry', entry);

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 
 import type {
@@ -27,6 +27,8 @@ export function useSectionForm(options?: UseSectionFormParams) {
   const { user } = useAuthState();
   const router = useRouter();
   const params = useParams<{ id?: string }>();
+  const searchParams = useSearchParams();
+  const entry = searchParams.get('entry');
 
   // URL 우선, props는 fallback
 
@@ -463,7 +465,15 @@ export function useSectionForm(options?: UseSectionFormParams) {
     if (typeof window !== 'undefined') {
       sessionStorage.setItem('courseDraft_step2', JSON.stringify(sections));
     }
-    router.push('/courses/create?step=1&from=section');
+    const params = new URLSearchParams();
+    params.set('step', '1');
+    if (entry) params.set('entry', entry);
+
+    router.push(`/courses/create?${params.toString()}`);
+  };
+
+  const handleCancel = () => {
+    router.push(entry ? decodeURIComponent(entry) : '/');
   };
 
   // create 모드에서 자동 세션 저장
@@ -493,5 +503,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
     handleLectureUpload,
     handleFinalSubmit,
     handlePrevStep,
+    handleCancel,
   };
 }

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -103,7 +103,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
 
   // === 초기 로딩 ===
   useEffect(() => {
-    if (!courseId) return;
     if (initialized) return;
 
     const load = async () => {
@@ -389,6 +388,33 @@ export function useSectionForm(options?: UseSectionFormParams) {
   // === 최종 등록 버튼 ===
   const handleFinalSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    if (process.env.NODE_ENV === 'development') {
+      console.group('[STEP2] Curriculum Draft');
+
+      sections.forEach((section, sIdx) => {
+        console.group(`Section ${sIdx + 1}: ${section.title}`);
+
+        section.lectures.forEach((lecture, lIdx) => {
+          console.log(`Lecture ${lIdx + 1}`, {
+            title: lecture.title,
+            duration: lecture.duration,
+            videoUrl: lecture.videoUrl,
+            isPreview: lecture.isPreview,
+            resources: lecture.resource.map((res) => ({
+              resourceType: res.resourceType,
+              fileUrl: res.fileUrl,
+              isDownloadable: res.isDownloadable,
+            })),
+          });
+        });
+
+        console.groupEnd();
+      });
+
+      console.groupEnd();
+      return; // 🔥 DEV 확인용 종료
+    }
 
     if (submitting || drafting) return;
 

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -469,7 +469,7 @@ export function useSectionForm(options?: UseSectionFormParams) {
     params.set('step', '1');
     if (entry) params.set('entry', entry);
 
-    router.push(`/courses/create?${params.toString()}`);
+    router.push(`/courses/create?${params.toString()}&from=section`);
   };
 
   const handleCancel = () => {

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -413,7 +413,14 @@ export function useSectionForm(options?: UseSectionFormParams) {
       });
 
       console.groupEnd();
-      return; // 🔥 DEV 확인용 종료
+
+      sessionStorage.removeItem('courseDraft_step1');
+      sessionStorage.removeItem('courseDraft_step2');
+      const devCourseId = courseId || 'DEV_COURSE_ID';
+      sessionStorage.setItem('draftCourseId', devCourseId);
+      alert('개발 모드: 강좌가 완료된 것으로 처리합니다.');
+      router.replace(`/courses/${devCourseId}`);
+      return;
     }
 
     if (submitting || drafting) return;

--- a/src/domains/course/services/courseCreateService.ts
+++ b/src/domains/course/services/courseCreateService.ts
@@ -56,6 +56,23 @@ export const createCourse = async (
 
 // 카테고리 조회 API
 export const getCategories = async (): Promise<Category[]> => {
+  if (process.env.NODE_ENV === 'development') {
+    return [
+      {
+        categoryId: 1,
+        name: '프로그래밍',
+        children: [
+          { categoryId: 2, name: '프론트엔드' },
+          { categoryId: 3, name: '백엔드' },
+        ],
+      },
+      {
+        categoryId: 4,
+        name: '디자인',
+        children: [{ categoryId: 5, name: 'UI/UX' }],
+      },
+    ];
+  }
   try {
     const categories = await getApi<Category[]>('/api/categories');
     return categories;

--- a/src/domains/user/pages/InstructorClientPage.tsx
+++ b/src/domains/user/pages/InstructorClientPage.tsx
@@ -61,7 +61,7 @@ export default function InstructorCourseClientPage() {
             <div className={styles['authored__item']}>
               <div className={styles['authored__meta']}>
                 <h3 className={styles['authored__title']}>{course.title}</h3>
-                <p className={styles['authored__category']}>{course.categories.join(' / ')}</p>
+                <p className={styles['authored__category']}></p>
               </div>
 
               {/* <div className={styles["authored__actions"]}>

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -10,11 +10,14 @@ import { LoginModal } from '@/domains/auth/components/LoginModal';
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import { logoutAction } from '@/domains/auth/actions/logoutAction';
 import styles from './Header.module.css';
+import { useCourseCreateEntry } from '@/domains/course/hooks/useCourseCreateEntry';
 
 export function Header() {
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
+
+  const { startCreateCourse } = useCourseCreateEntry();
 
   const { user, loading, clearUser } = useAuthState();
   const [menuOpen, setMenuOpen] = useState(false);
@@ -106,12 +109,12 @@ export function Header() {
               )}
 
               {user && isInstructor && (
-                <Link
-                  href="/courses/create?step=1"
+                <button
+                  onClick={startCreateCourse}
                   className={`${styles['header__action']} ${styles['header__action--cta']}`}
                 >
                   강좌 등록하기
-                </Link>
+                </button>
               )}
             </nav>
 


### PR DESCRIPTION
## 변경 사항

- 강좌 등록 step1, step2 폼 데이터 콘솔 로그 추가 (DEV 전용)
- 단계 이동 시 현재 폼 필드 값을 localStorage에 저장
- 이전 단계로 이동해도 입력값이 유지되도록 처리

## 리뷰 필요

- [x] step2 → step1 이동 시 기존 입력값 유지
- [x] step1 → step2 재진입 시 커리큘럼 데이터 유지
- [x] 단계 이동 시 sessionStorage에 폼 데이터 저장됨
- [x] 새로고침 시 저장된 데이터가 정상적으로 복원됨 (의도된 경우)
- [ ] 강좌 등록 완료 후 임시 데이터 제거 또는 무시 확인
- [x] step2 에서 취소 버튼 누를 시, 이전 페이지(step1 X)로 돌아가기

close #87 
