### PR TITLE
refactor: 강좌·섹션 폼 및 썸네일/리소스 업로더 구조 정리

### DIFF
--- a/src/app/courses/create/CourseCreatePage.module.css
+++ b/src/app/courses/create/CourseCreatePage.module.css
@@ -1,13 +1,24 @@
 .course-create {
   display: grid;
-  gap: var(--space-5);
-  padding-block: var(--space-6) var(--space-9);
+  gap: var(--space-4);
+  padding-block: var(--space-6) var(--space-8);
+  position: relative;
 }
 
 .course-create__header {
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  background: linear-gradient(135deg, rgba(239, 104, 23, 0.1), rgba(239, 104, 23, 0) 60%);
+  border: 1px solid rgba(239, 104, 23, 0.2);
+}
+
+.course-create__heading {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
 }
 
 .course-create__title {
@@ -16,16 +27,98 @@
   font-weight: 700;
 }
 
+.course-create__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.course-create__steps {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin: 0;
+  padding: 0;
+  width: 100%;
+}
+
+.course-create__step {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  flex: 1 1 0;
+  min-width: 0;
+  justify-content: center;
+  border-radius: var(--radius-md);
+  border: 1px solid transparent;
+  background: rgba(17, 24, 39, 0.04);
+  color: var(--color-text-muted);
+  font-size: var(--text-xs);
+  font-weight: 600;
+  line-height: 1.2;
+  min-height: 32px;
+}
+
+.course-create__step--active {
+  border-color: rgba(239, 104, 23, 0.45);
+  color: var(--color-text);
+  background: rgba(239, 104, 23, 0.12);
+}
+
+.course-create__step--complete {
+  border-color: rgba(16, 185, 129, 0.35);
+  color: var(--color-text);
+  background: rgba(16, 185, 129, 0.1);
+}
+
+.course-create__step-number {
+  width: 22px;
+  height: 22px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(17, 24, 39, 0.08);
+  color: var(--color-text);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.course-create__step--active .course-create__step-number {
+  background: rgba(239, 104, 23, 0.18);
+  color: var(--color-brand);
+}
+
+.course-create__step--complete .course-create__step-number {
+  background: rgba(16, 185, 129, 0.18);
+  color: var(--color-success);
+}
+
+.course-create__step-text {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
 .course-create__body {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   background: var(--color-elevated);
-  padding: var(--space-6);
-  /* box-shadow: var(--shadow-sm); */
+  padding: var(--space-4);
 }
 
 @media (min-width: 768px) {
   .course-create {
     padding-block: var(--space-8);
+  }
+
+  .course-create__header {
+    padding: var(--space-5);
+  }
+
+  .course-create__body {
+    padding: var(--space-5);
   }
 }

--- a/src/domains/course/components/CourseForm.module.css
+++ b/src/domains/course/components/CourseForm.module.css
@@ -1,7 +1,11 @@
 .course-form {
   display: flex;
   flex-direction: column;
-  gap: var(--space-5);
+  gap: var(--space-6);
+}
+
+.course-form > * {
+  min-width: 0;
 }
 
 .course-form__field,
@@ -9,6 +13,10 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-2);
+}
+
+.form__field-item {
+  flex: 1;
 }
 
 .course-form__label {
@@ -43,6 +51,24 @@
     box-shadow 0.2s ease;
 }
 
+.course-form__select {
+  appearance: none;
+  padding-right: var(--space-8);
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--color-text-muted) 50%),
+    linear-gradient(135deg, var(--color-text-muted) 50%, transparent 50%),
+    linear-gradient(to right, var(--color-border), var(--color-border));
+  background-position:
+    calc(100% - 18px) 50%,
+    calc(100% - 13px) 50%,
+    calc(100% - 40px) 50%;
+  background-size:
+    5px 5px,
+    5px 5px,
+    1px 24px;
+  background-repeat: no-repeat;
+}
+
 .course-form__textarea {
   resize: vertical;
   min-height: 160px;
@@ -68,7 +94,7 @@
   border-radius: var(--radius-sm);
   padding: var(--space-3) var(--space-5);
   background: var(--color-brand);
-  color: var(--color-text);
+  color: var(--color-text-light);
   font-weight: 600;
   text-decoration: none;
   display: inline-flex;
@@ -118,14 +144,34 @@
   aspect-ratio: 16 / 11;
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
+  min-height: 180px;
   background: repeating-linear-gradient(
     135deg,
-    rgba(79, 70, 229, 0.06),
-    rgba(79, 70, 229, 0.06) 12px,
+    rgba(239, 104, 23, 0.08),
+    rgba(239, 104, 23, 0.08) 12px,
     transparent 12px,
     transparent 24px
   );
   object-fit: cover;
+}
+
+.upload__preview[data-has-image='false'] {
+  background: linear-gradient(135deg, rgba(17, 24, 39, 0.02), rgba(17, 24, 39, 0.08));
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  font-size: var(--text-sm);
+}
+
+.upload__preview-placeholder {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-3) var(--space-4);
+  border: 1px dashed var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
 }
 
 .upload__preview img {
@@ -153,7 +199,15 @@
 .upload__trigger:hover,
 .upload__trigger:focus-visible {
   border-color: var(--color-brand);
-  background: rgba(79, 70, 229, 0.08);
+  background: rgba(239, 104, 23, 0.08);
+}
+
+.upload__info-header {
+  display: flex;
+  column-gap: var(--space-2);
+  justify-content: space-between;
+  flex-direction: row;
+  align-items: center;
 }
 
 .upload__hint {
@@ -174,7 +228,7 @@
 }
 
 .form-grid {
-  /* display: grid; */
+  display: grid;
   gap: var(--space-4);
   grid-template-columns: 1fr;
 }
@@ -193,6 +247,14 @@
   letter-spacing: 0.04em;
 }
 
+.form__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-size: var(--text-sm);
+  color: var(--color-text);
+}
+
 .form__control {
   display: flex;
   flex-wrap: wrap;
@@ -204,6 +266,24 @@
   color: var(--color-text);
 }
 
+.form__control:where(select) {
+  appearance: none;
+  padding-right: var(--space-8);
+  background-image:
+    linear-gradient(45deg, transparent 50%, var(--color-text-muted) 50%),
+    linear-gradient(135deg, var(--color-text-muted) 50%, transparent 50%),
+    linear-gradient(to right, var(--color-border), var(--color-border));
+  background-position:
+    calc(100% - 18px) 50%,
+    calc(100% - 13px) 50%,
+    calc(100% - 40px) 50%;
+  background-size:
+    5px 5px,
+    5px 5px,
+    1px 24px;
+  background-repeat: no-repeat;
+}
+
 .form__control:focus-visible {
   border-color: var(--color-brand);
   /* box-shadow: 0 0 0 2px rgba(79, 70, 229, 0.35); */
@@ -211,18 +291,53 @@
 }
 
 .upload-card {
+  display: grid;
+  grid-template-columns: 1fr;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-lg);
   background: var(--color-surface);
   padding: var(--space-4);
-  display: grid;
   gap: var(--space-3);
   align-content: start;
+}
+
+.upload-card__item {
+  display: flex;
+  flex-direction: column;
+  background: var(--color-surface);
+  gap: var(--space-3);
+}
+
+.upload-card__preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.upload-card--thumbnail {
+  grid-template-columns: 1fr;
 }
 
 .upload__actions {
   display: flex;
   gap: var(--space-2);
+}
+
+.upload__info {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  padding: var(--space-2) 0;
+}
+
+.upload__info--bottom {
+  margin-top: auto;
+}
+
+.upload__status {
+  margin: 0;
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
 }
 
 .upload__button {
@@ -242,6 +357,28 @@
 .upload__button:focus-visible {
   border-color: var(--color-brand);
   color: var(--color-brand-700);
+}
+
+.upload__remove-btn {
+  border: 1px solid var(--color-border);
+  border-radius: 999px;
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  background: var(--color-surface);
+  cursor: pointer;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.upload__remove-btn:hover,
+.upload__remove-btn:focus-visible {
+  border-color: var(--color-danger);
+  color: var(--color-danger);
 }
 
 .form-actions {
@@ -346,6 +483,7 @@
   background: var(--color-surface);
   color: var(--color-text);
   font-size: var(--text-sm);
+  white-space: nowrap;
   cursor: pointer;
   transition:
     border-color 0.2s ease,
@@ -359,6 +497,17 @@
   color: var(--color-brand-700);
 }
 
+.section-list__action--danger {
+  border-color: rgba(239, 68, 68, 0.35);
+  color: var(--color-danger);
+}
+
+.section-list__action--danger:hover,
+.section-list__action--danger:focus-visible {
+  border-color: var(--color-danger);
+  background: rgba(239, 68, 68, 0.08);
+}
+
 .section-list__footer {
   margin-top: var(--space-4);
   display: flex;
@@ -368,28 +517,45 @@
 .lecture-list {
   list-style: none;
   margin: 0;
-  padding: 0;
+  padding: 0 0 0 var(--space-4);
   display: grid;
   gap: var(--space-3);
+  border-left: 2px solid rgba(17, 24, 39, 0.08);
 }
 
 .lecture-list__item {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  justify-content: space-between;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
   gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  background: var(--color-elevated);
 }
 
 .lecture-list__edit-group {
   display: flex;
+  flex-direction: column;
   flex: 1;
-  align-items: center;
   gap: var(--space-2);
 }
 
+.lecture-list__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+}
+
+.lecture-list__title-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: var(--space-2);
+  align-items: center;
+}
+
 .lecture-list__edit-group input[type='text'] {
-  flex: 1;
+  /* flex: 1; */
   min-width: 0;
 }
 
@@ -410,12 +576,13 @@
 }
 
 .lecture-list__action {
-  padding: var(--space-1) var(--space-3);
+  padding: var(--space-2) var(--space-3);
   border-radius: var(--radius-sm);
   border: 1px solid var(--color-border);
   background: var(--color-elevated);
   color: var(--color-text);
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
+  white-space: nowrap;
   cursor: pointer;
   transition:
     border-color 0.2s ease,
@@ -454,10 +621,24 @@
   }
 }
 
+@media (min-width: 900px) {
+  .upload-card {
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+    align-items: start;
+  }
+
+  .upload-card--thumbnail {
+    grid-template-columns: 1fr;
+  }
+
+  .upload-card__preview {
+    padding-top: calc(var(--text-sm) + var(--space-2));
+  }
+}
+
 @media (min-width: 1200px) {
   .form-grid {
-    grid-template-columns: 1fr 420px;
-    align-items: start;
+    grid-template-columns: 1fr;
   }
 }
 
@@ -465,4 +646,74 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-3);
+}
+
+@media (max-width: 640px) {
+  .form-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .btn,
+  .course-form__button,
+  .course-form__button--ghost {
+    width: 100%;
+  }
+}
+
+@media (max-width: 767px) {
+  .upload-card {
+    padding: var(--space-3);
+  }
+
+  .upload__preview {
+    min-height: 120px;
+  }
+
+  .lecture-list__item {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .lecture-list {
+    padding-left: var(--space-3);
+  }
+
+  .lecture-list__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .lecture-list__header .lecture-list__action {
+    width: 100%;
+  }
+
+  .lecture-list__title-row {
+    grid-template-columns: 1fr;
+  }
+
+  .lecture-list__title-row .lecture-list__action {
+    width: 100%;
+  }
+
+  .lecture-list__action {
+    width: 100%;
+  }
+
+  .section-list__header {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .section-list__actions {
+    width: 100%;
+  }
+
+  .section-list__action {
+    width: 100%;
+  }
+
+  .upload-card--thumbnail .upload__preview {
+    min-height: 110px;
+  }
 }

--- a/src/domains/course/components/CourseForm.tsx
+++ b/src/domains/course/components/CourseForm.tsx
@@ -1,13 +1,11 @@
 'use client';
 
+import { useCourseForm } from '../hooks/useCourseForm';
 import styles from './CourseForm.module.css';
 import { SelectCategory } from './SelectCategory';
 import { ThumbnailUploader } from './ThumbnailUploader';
-import { useCourseForm } from '../hooks/useCourseForm';
-import { useRouter } from 'next/navigation';
 
 export function CourseForm() {
-  const router = useRouter();
   const {
     formData,
     loading,

--- a/src/domains/course/components/ResourceUploader.tsx
+++ b/src/domains/course/components/ResourceUploader.tsx
@@ -67,7 +67,6 @@ export function ResourceUploader({
   const [draftFileName, setDraftFileName] = useState<string>('');
   const [draftDuration, setDraftDuration] = useState<number | null>(null);
   const [draftIsDownloadable, setDraftIsDownloadable] = useState<boolean | null>(null);
-  const [draftFile, setDraftFile] = useState<File | null>(null);
 
   const inputRef = useRef<HTMLInputElement | null>(null);
   const blobUrlRef = useRef<string | null>(null);
@@ -112,7 +111,6 @@ export function ResourceUploader({
     setDraftPreviewUrl('');
     setDraftFileName('');
     setDraftDuration(null);
-    setDraftFile(null);
     if (inputRef.current) inputRef.current.value = '';
   };
 
@@ -151,7 +149,6 @@ export function ResourceUploader({
 
     setUploading(true);
     setDraftFileName(file.name);
-    setDraftFile(file);
 
     // 이전 blob 정리 후 새 blob 생성
     revokeBlobIfAny();

--- a/src/domains/course/components/ResourceUploader.tsx
+++ b/src/domains/course/components/ResourceUploader.tsx
@@ -111,6 +111,7 @@ export function ResourceUploader({
     setDraftPreviewUrl('');
     setDraftFileName('');
     setDraftDuration(null);
+    setDraftIsDownloadable(null);
     if (inputRef.current) inputRef.current.value = '';
   };
 

--- a/src/domains/course/components/ResourceUploader.tsx
+++ b/src/domains/course/components/ResourceUploader.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { useEffect, useState, type ChangeEvent } from 'react';
-import { formatDuration } from '../utils/formatDuration';
-import styles from './CourseForm.module.css';
+import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+import { formatDuration, formatLectureDuration } from '../utils/formatDuration';
 import { RESOURCE_CONFIG } from '../constants/resource';
+import styles from './CourseForm.module.css';
 
 export type ResourceType = 'VIDEO' | 'PDF' | 'DOC' | 'ZIP';
 
 export type UploadResult = {
   resourceType: ResourceType;
   fileUrl: string;
+  previewUrl?: string;
   isDownloadable: boolean;
   duration?: number | null;
   fileName?: string | undefined;
@@ -22,225 +23,275 @@ type ResourceUploaderProps = {
   onRemove?: () => void;
 };
 
+function getFileNameFromUrl(url: string) {
+  if (!url) return '';
+  const raw = url.split('/').pop()?.split('?')[0] ?? '';
+  try {
+    return raw ? decodeURIComponent(raw) : '';
+  } catch {
+    return raw;
+  }
+}
+
+async function getVideoDurationSeconds(url: string): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video');
+    video.preload = 'metadata';
+    video.src = url;
+
+    video.onloadedmetadata = () => {
+      const totalSeconds = Number.isFinite(video.duration) ? video.duration : 0;
+      const roundedSeconds = Math.max(0, Math.round(totalSeconds));
+
+      // 메모리 정리
+      video.removeAttribute('src');
+      video.load();
+
+      resolve(roundedSeconds);
+    };
+
+    video.onerror = () => reject(new Error('비디오 메타데이터를 읽을 수 없습니다.'));
+  });
+}
+
 export function ResourceUploader({
   initialValue,
   onUploadComplete,
   onRemove,
 }: ResourceUploaderProps) {
-  const [resourceType, setResourceType] = useState<ResourceType>(
-    initialValue?.resourceType ?? 'VIDEO',
-  );
-
+  // ===== "로컬(draft)"만 state로 관리 (props->state 동기화 useEffect 제거) =====
+  const [draftType, setDraftType] = useState<ResourceType | null>(null);
   const [uploading, setUploading] = useState(false);
-  const [fileName, setFileName] = useState(initialValue?.fileName ?? '');
-  const [fileUrl, setFileUrl] = useState('');
-  const [duration, setDuration] = useState<number | null>(initialValue?.duration ?? null);
-  const [isDownloadable, setIsDownloadable] = useState(initialValue?.isDownloadable ?? false);
 
-  useEffect(() => {
-    if (initialValue && initialValue.fileUrl !== fileUrl) {
-      setResourceType(initialValue.resourceType);
-      setFileName(initialValue.fileName ?? '');
-      setFileUrl(initialValue.fileUrl);
-      setDuration(initialValue.duration ?? null);
-      setIsDownloadable(initialValue.isDownloadable);
-      const extractedName =
-        initialValue.fileName ?? initialValue.fileUrl.split('/').pop()?.split('?')[0] ?? '';
-      setFileName(extractedName ? decodeURIComponent(extractedName) : '');
+  const [draftPreviewUrl, setDraftPreviewUrl] = useState<string>(''); // blob url
+  const [draftFileName, setDraftFileName] = useState<string>('');
+  const [draftDuration, setDraftDuration] = useState<number | null>(null);
+  const [draftIsDownloadable, setDraftIsDownloadable] = useState<boolean | null>(null);
+  const [draftFile, setDraftFile] = useState<File | null>(null);
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+  const blobUrlRef = useRef<string | null>(null);
+
+  const effectiveType: ResourceType = draftType ?? initialValue?.resourceType ?? 'VIDEO';
+
+  const initialUrl = initialValue?.fileUrl ?? '';
+  const effectivePreviewUrl = draftPreviewUrl || initialUrl;
+
+  const initialName = initialValue?.fileName ?? getFileNameFromUrl(initialUrl);
+
+  const effectiveFileName = draftFileName || initialName;
+
+  const effectiveDuration =
+    effectiveType === 'VIDEO' ? (draftDuration ?? initialValue?.duration ?? null) : null;
+
+  const effectiveIsDownloadable =
+    effectiveType === 'VIDEO'
+      ? false
+      : (draftIsDownloadable ?? initialValue?.isDownloadable ?? true);
+
+  const config = RESOURCE_CONFIG[effectiveType];
+  const maxSizeBytes = useMemo(() => config.maxSizeMB * 1024 * 1024, [config.maxSizeMB]);
+
+  const revokeBlobIfAny = () => {
+    if (blobUrlRef.current) {
+      URL.revokeObjectURL(blobUrlRef.current);
+      blobUrlRef.current = null;
     }
-  }, [initialValue]);
+  };
+
+  // 언마운트 시 blob 정리 (setState 없음)
+  useEffect(() => {
+    return () => {
+      revokeBlobIfAny();
+    };
+  }, []);
+
+  const resetDraftFileOnly = () => {
+    revokeBlobIfAny();
+    setUploading(false);
+    setDraftPreviewUrl('');
+    setDraftFileName('');
+    setDraftDuration(null);
+    setDraftFile(null);
+    if (inputRef.current) inputRef.current.value = '';
+  };
 
   const handleResourceTypeChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const newType = e.target.value as ResourceType;
-    if (fileName) {
+
+    if (effectiveFileName) {
       const confirmed = window.confirm(
         '파일 종류를 변경하면 업로드된 파일이 초기화됩니다. 계속하시겠습니까?',
       );
       if (!confirmed) return;
     }
 
-    setResourceType(newType);
+    // 타입 바꾸면 파일은 초기화
+    resetDraftFileOnly();
 
-    setFileName('');
-    setFileUrl('');
-    setDuration(null);
-    setIsDownloadable(newType !== 'VIDEO');
+    setDraftType(newType);
+    // VIDEO는 다운로드 불가, 나머지는 기본 true
+    setDraftIsDownloadable(newType !== 'VIDEO');
   };
 
   const handleRemoveFile = () => {
-    setFileName('');
-    setFileUrl('');
-    setDuration(null);
+    resetDraftFileOnly();
     onRemove?.();
   };
+
   const handleFileChange = async (e: ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    const maxSize = RESOURCE_CONFIG[resourceType].maxSizeMB * 1024 * 1024;
-    if (file.size > maxSize) {
-      alert(`파일 크기는 ${RESOURCE_CONFIG[resourceType].maxSizeMB}MB 이하여야 합니다.`);
+    if (file.size > maxSizeBytes) {
+      alert(`파일 크기는 ${config.maxSizeMB}MB 이하여야 합니다.`);
+      resetDraftFileOnly();
       return;
     }
 
     setUploading(true);
-    setFileName(file.name);
+    setDraftFileName(file.name);
+    setDraftFile(file);
+
+    // 이전 blob 정리 후 새 blob 생성
+    revokeBlobIfAny();
+    const objectUrl = URL.createObjectURL(file);
+    blobUrlRef.current = objectUrl;
+    setDraftPreviewUrl(objectUrl);
 
     try {
-      const url = URL.createObjectURL(file);
-      setFileUrl(url);
-      const storedUrl = `/uploads/${encodeURIComponent(file.name)}`;
+      let videoSeconds: number | null = null;
 
-      let videoDuration: number | null = null;
-
-      if (resourceType === 'VIDEO') {
-        videoDuration = await calculateVideoDuration(url, file.name);
-        setDuration(videoDuration);
+      if (effectiveType === 'VIDEO') {
+        videoSeconds = await getVideoDurationSeconds(objectUrl);
+        setDraftDuration(videoSeconds);
       } else {
-        setDuration(null);
+        setDraftDuration(null);
       }
+
+      // 저장용 URL (지금은 더미. 실제로는 업로드 API 응답에서 받는 게 정석)
+      const storedUrl = `/uploads/${encodeURIComponent(file.name)}`;
 
       setUploading(false);
 
       onUploadComplete?.({
-        resourceType,
-        fileUrl: storedUrl, // 서버/JSON에 저장될 값: blob 말고 문자열 경로
-        isDownloadable,
-        duration: videoDuration ?? undefined,
+        resourceType: effectiveType,
+        fileUrl: storedUrl,
+        previewUrl: objectUrl,
+        isDownloadable: effectiveType === 'VIDEO' ? false : effectiveIsDownloadable,
+        duration: videoSeconds ?? undefined,
         fileName: file.name,
-        file,
-      } as UploadResult);
+        multiFile: file,
+      });
     } catch (err) {
       let msg = '파일 처리 중 오류가 발생했습니다.';
-
       if (err instanceof Error) {
-        if (err.message.includes('metadata')) {
-          msg = '비디오 파일이 손상되었거나 지원하지 않는 형식입니다.';
-        } else {
-          msg = err.message;
-        }
+        msg = err.message.includes('metadata')
+          ? '비디오 파일이 손상되었거나 지원하지 않는 형식입니다.'
+          : err.message;
       }
-
       alert(msg);
-      setUploading(false);
-
-      setFileName('');
-      setFileUrl('');
-      setDuration(null);
+      resetDraftFileOnly();
     }
   };
 
-  {
-    /*const formData = new FormData();
-formData.append('file', file);
-formData.append('resourceType', resourceType);
-
-const uploadRes = await fetch(`${BASE_URL}/files`, {
-  method: 'POST',
-  body: formData,
-});
-if (!uploadRes.ok) throw new Error('파일 업로드에 실패했습니다.');
-
-const uploadJson = await uploadRes.json();
-const storedUrl = uploadJson.data.fileUrl;  // 이제 진짜 URL*/
-  }
-
-  const calculateVideoDuration = (url: string, name: string): Promise<number> => {
-    return new Promise((resolve, reject) => {
-      const tempVideo = document.createElement('video');
-      tempVideo.preload = 'metadata';
-      tempVideo.src = url;
-
-      tempVideo.onloadedmetadata = () => {
-        const totalSeconds = tempVideo.duration || 0;
-        const totalMinutes = Math.floor(totalSeconds / 60);
-
-        setDuration(totalMinutes);
-        setUploading(false);
-        resolve(totalMinutes);
-      };
-
-      tempVideo.onerror = () => {
-        reject(new Error('비디오 메타데이터를 읽을 수 없습니다.'));
-      };
-    });
-  };
-
-  const config = RESOURCE_CONFIG[resourceType];
-
   return (
     <div className={styles['upload-card']}>
-      {/* ===== 파일 종류 선택 ===== */}
-      <div className={styles['form__field']}>
-        <label className={styles['form__label']}>파일 종류</label>
-        <select
-          value={resourceType}
-          onChange={handleResourceTypeChange}
-          disabled={uploading}
-          className={styles['form__control']}
-        >
-          <option value="VIDEO">동영상 (VIDEO)</option>
-          <option value="PDF">PDF 문서</option>
-          <option value="DOC">문서 파일 (DOC/DOCX)</option>
-          <option value="ZIP">압축 파일 (ZIP)</option>
-        </select>
-      </div>
-
-      {/* ===== 다운로드 가능 (VIDEO 제외) ===== */}
-      {resourceType !== 'VIDEO' && (
+      <div className={`${styles['form__field-item']} ${styles['upload-card__item']}`}>
+        {/* ===== 파일 종류 선택 ===== */}
         <div className={styles['form__field']}>
-          <label className={styles['form__checkbox']}>
-            <input
-              type="checkbox"
-              checked={isDownloadable}
-              onChange={(e) => setIsDownloadable(e.target.checked)}
-            />
-            <span>다운로드 가능</span>
-          </label>
+          <label className={styles['form__label']}>파일 종류</label>
+          <select
+            value={effectiveType}
+            onChange={handleResourceTypeChange}
+            disabled={uploading}
+            className={styles['form__control']}
+          >
+            <option value="VIDEO">동영상 (VIDEO)</option>
+            <option value="PDF">PDF 문서</option>
+            <option value="DOC">문서 파일 (DOC/DOCX)</option>
+            <option value="ZIP">압축 파일 (ZIP)</option>
+          </select>
         </div>
-      )}
 
-      {/* ===== 파일 선택 ===== */}
-      <div className={styles['form__field']}>
-        <label className={styles['form__label']}>파일 선택</label>
-        <input
-          type="file"
-          accept={config.accept}
-          onChange={handleFileChange}
-          disabled={uploading}
-          className={styles['form__control']}
-        />
+        {/* ===== 다운로드 가능 (VIDEO 제외) ===== */}
+        {effectiveType !== 'VIDEO' && (
+          <div className={styles['form__field']}>
+            <label className={styles['form__checkbox']}>
+              <input
+                type="checkbox"
+                checked={effectiveIsDownloadable}
+                onChange={(e) => setDraftIsDownloadable(e.target.checked)}
+              />
+              <span>다운로드 가능</span>
+            </label>
+          </div>
+        )}
+
+        {/* ===== 파일 선택 ===== */}
+        <div className={styles['form__field']}>
+          <label className={styles['form__label']}>파일 선택</label>
+          <input
+            ref={inputRef}
+            type="file"
+            accept={config.accept}
+            onChange={handleFileChange}
+            disabled={uploading}
+            className={styles['form__control']}
+          />
+          {!effectiveFileName && <p className={styles['upload__hint']}>{config.hint}</p>}
+        </div>
+
+        {uploading && <p className={styles['upload__status']}>업로드 중...</p>}
       </div>
 
-      {uploading && <p className={styles['upload__hint']}>업로드 중...</p>}
+      <div className={`${styles['form__field-item']} ${styles['upload-card__preview']}`}>
+        {effectiveType === 'VIDEO' && effectivePreviewUrl && (
+          <video
+            src={effectivePreviewUrl}
+            controls
+            className={styles['upload__preview']}
+            onLoadedMetadata={(event) => {
+              // draftDuration 없을 때만 보정
+              if (draftDuration && draftDuration > 0) return;
+              const secs = Math.max(0, Math.round(event.currentTarget.duration || 0));
+              if (secs > 0) setDraftDuration(secs);
+            }}
+          />
+        )}
 
-      {resourceType === 'VIDEO' && fileUrl && (
-        <video src={fileUrl} controls className={styles['upload__preview']} />
-      )}
+        {effectiveFileName && !uploading && (
+          <div className={`${styles['upload__info']} ${styles['upload__info--bottom']}`}>
+            <div className={styles['upload__info-header']}>
+              <p className={styles['upload__hint']}>
+                {effectiveFileName}
+                {effectiveType === 'VIDEO' && effectiveDuration !== null && (
+                  <span>
+                    {' '}
+                    (길이:{' '}
+                    {effectiveDuration >= 60
+                      ? formatDuration(Math.max(1, Math.round(effectiveDuration / 60)))
+                      : formatLectureDuration(effectiveDuration)}
+                    )
+                  </span>
+                )}
+              </p>
 
-      {fileName && !uploading && (
-        <div className={styles['upload__info']}>
-          <div className={styles['upload__info-header']}>
-            <p className={styles['upload__hint']}>
-              📎 {fileName}
-              {resourceType === 'VIDEO' && duration !== null && (
-                <span> (길이: {formatDuration(duration)})</span>
-              )}
-            </p>
-            <button
-              type="button"
-              onClick={handleRemoveFile}
-              className={styles['upload__remove-btn']}
-            >
-              ✕
-            </button>
+              <button
+                type="button"
+                onClick={handleRemoveFile}
+                className={styles['upload__remove-btn']}
+              >
+                ✕
+              </button>
+            </div>
+
+            {effectiveIsDownloadable && effectiveType !== 'VIDEO' && (
+              <p className={styles['upload__hint']}>다운로드 가능</p>
+            )}
           </div>
-          {isDownloadable && resourceType !== 'VIDEO' && (
-            <p className={styles['upload__hint']}>✅ 다운로드 가능</p>
-          )}
-        </div>
-      )}
-      {!fileName && <p className={styles['upload__hint']}>{config.hint}</p>}
+        )}
+      </div>
     </div>
   );
 }

--- a/src/domains/course/components/SectionForm.tsx
+++ b/src/domains/course/components/SectionForm.tsx
@@ -1,13 +1,12 @@
 'use client';
-import { useRouter } from 'next/navigation';
-
+import { useMemo, useState } from 'react';
+import { useSectionForm } from '../hooks/useSectionForm';
+import { ResourceType } from '../types/course';
 import styles from './CourseForm.module.css';
 import { ResourceUploader } from './ResourceUploader';
-import { useSectionForm } from '../hooks/useSectionForm';
-import { LectureResource, ResourceType } from '../types/course';
 
 export function SectionForm() {
-  const router = useRouter();
+  const [collapsedSections, setCollapsedSections] = useState<Set<string>>(new Set());
   const {
     sections,
     step1Data,
@@ -23,24 +22,39 @@ export function SectionForm() {
     handleSectionTitleChange,
     handleLectureTitleChange,
     handleLectureUpload,
+    handleLectureRemoveResource,
     handleFinalSubmit,
     handlePrevStep,
     handleCancel,
   } = useSectionForm();
 
+  const toggleSection = (sectionId: string) => {
+    setCollapsedSections((prev) => {
+      const next = new Set(prev);
+      if (next.has(sectionId)) {
+        next.delete(sectionId);
+      } else {
+        next.add(sectionId);
+      }
+      return next;
+    });
+  };
+
+  const lectureCounts = useMemo(
+    () =>
+      sections.reduce<Record<string, number>>((acc, section) => {
+        acc[section.localId] = section.lectures.filter((lecture) => !lecture._deleted).length;
+        return acc;
+      }, {}),
+    [sections],
+  );
+
   if (!step1Data) {
     return <p>강좌 기본 정보를 불러오는 중입니다. 잠시만 기다려주세요...</p>;
   }
 
-  // if (!savedCourseId) {
-  //   router.replace('/courses/create?step=1');
-  //   return;
-  // }
-
   return (
     <form onSubmit={handleFinalSubmit}>
-      <h1>강좌 섹션 및 강의 </h1>
-
       <div className={styles['course-form__field']}>
         <label htmlFor="lecture" className={styles['form__label']}>
           섹션 <span className={styles['course-form__req']}>*</span>
@@ -62,6 +76,14 @@ export function SectionForm() {
                   <button
                     type="button"
                     className={styles['section-list__action']}
+                    onClick={() => toggleSection(section.localId)}
+                  >
+                    {collapsedSections.has(section.localId) ? '섹션 펼치기' : '섹션 접기'} (
+                    {lectureCounts[section.localId] ?? 0})
+                  </button>
+                  <button
+                    type="button"
+                    className={`${styles['section-list__action']} ${styles['section-list__action--danger']}`}
                     onClick={() => handleSectionDelete(section.localId)}
                   >
                     섹션 삭제
@@ -69,62 +91,79 @@ export function SectionForm() {
                 </div>
               </header>
 
-              <ul className={styles['lecture-list']}>
-                {section.lectures
-                  .filter((lecture) => !lecture._deleted) // 삭제된 강의 제외
-                  .map((lecture) => (
-                    <li key={lecture.localId} className={styles['lecture-list__item']}>
-                      <div className={styles['lecture-list__edit-group']}>
-                        <ResourceUploader
-                          initialValue={
-                            lecture.resource?.[0]
-                              ? {
-                                  resourceType: lecture.resource[0].resourceType as ResourceType,
-                                  fileUrl: lecture.resource[0].fileUrl ?? '',
-                                  isDownloadable: !!lecture.resource[0].isDownloadable,
-                                  duration: lecture.duration,
-                                  fileName: undefined,
+              {!collapsedSections.has(section.localId) && (
+                <>
+                  <ul className={styles['lecture-list']}>
+                    {section.lectures
+                      .filter((lecture) => !lecture._deleted) // 삭제된 강의 제외
+                      .map((lecture) => (
+                        <li key={lecture.localId} className={styles['lecture-list__item']}>
+                          <div className={styles['lecture-list__edit-group']}>
+                            <label htmlFor="lecture" className={styles['form__label']}>
+                              강의 <span className={styles['course-form__req']}>*</span>
+                            </label>
+                            <div className={styles['lecture-list__title-row']}>
+                              <input
+                                type="text"
+                                value={lecture.title}
+                                onChange={(e) =>
+                                  handleLectureTitleChange(
+                                    section.localId,
+                                    lecture.localId,
+                                    e.target.value,
+                                  )
                                 }
-                              : undefined
-                          }
-                          onUploadComplete={(result) =>
-                            handleLectureUpload(section.localId, lecture.localId, result)
-                          }
-                        />
+                                className={styles['course-form__input']}
+                                placeholder="강의 제목 입력"
+                              />
+                              <button
+                                type="button"
+                                className={`${styles['lecture-list__action']} ${styles['lecture-list__action--danger']}`}
+                                onClick={() =>
+                                  handleLectureDelete(section.localId, lecture.localId)
+                                }
+                              >
+                                강의 삭제
+                              </button>
+                            </div>
+                            <ResourceUploader
+                              key={lecture.localId}
+                              initialValue={
+                                lecture.resource?.[0]
+                                  ? {
+                                      resourceType: lecture.resource[0]
+                                        .resourceType as ResourceType,
+                                      fileUrl:
+                                        lecture.resource[0].resourceType === 'VIDEO'
+                                          ? (lecture.videoUrl ?? lecture.resource[0].fileUrl ?? '')
+                                          : (lecture.resource[0].fileUrl ?? ''),
+                                      isDownloadable: !!lecture.resource[0].isDownloadable,
+                                      duration: lecture.duration,
+                                      fileName: undefined,
+                                    }
+                                  : undefined
+                              }
+                              onUploadComplete={(result) =>
+                                handleLectureUpload(section.localId, lecture.localId, result)
+                              }
+                              onRemove={() =>
+                                handleLectureRemoveResource(section.localId, lecture.localId)
+                              }
+                            />
+                          </div>
+                        </li>
+                      ))}
+                  </ul>
 
-                        <input
-                          type="text"
-                          value={lecture.title}
-                          onChange={(e) =>
-                            handleLectureTitleChange(
-                              section.localId,
-                              lecture.localId,
-                              e.target.value,
-                            )
-                          }
-                          className={styles['course-form__input']}
-                          placeholder="강의 제목 입력"
-                        />
-                      </div>
-
-                      <button
-                        type="button"
-                        className={`${styles['lecture-list__action']} ${styles['lecture-list__action--danger']}`}
-                        onClick={() => handleLectureDelete(section.localId, lecture.localId)}
-                      >
-                        강의 삭제
-                      </button>
-                    </li>
-                  ))}
-              </ul>
-
-              <button
-                type="button"
-                className={styles['section-list__action']}
-                onClick={() => handleLectureAdd(section.localId)}
-              >
-                + 강의 추가
-              </button>
+                  <button
+                    type="button"
+                    className={styles['section-list__action']}
+                    onClick={() => handleLectureAdd(section.localId)}
+                  >
+                    + 강의 추가
+                  </button>
+                </>
+              )}
             </div>
           ))}
 

--- a/src/domains/course/components/SelectCategory.tsx
+++ b/src/domains/course/components/SelectCategory.tsx
@@ -1,13 +1,12 @@
-// src/domains/course/components/SelectCategory.tsx
 'use client';
 
 import { useEffect, useState, ChangeEvent } from 'react';
-import styles from './CourseForm.module.css';
 import { getCategories } from '../services/courseCreateService';
 import type { Category } from '../types/course';
+import styles from './CourseForm.module.css';
 
 type SelectCategoryProps = {
-  value?: string[]; // [firstId, secondId] (문자열)
+  value?: string[];
   onChange?: (value: string[]) => void;
   id?: string;
 };
@@ -17,10 +16,10 @@ export function SelectCategory({ value = [], onChange, id }: SelectCategoryProps
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  const firstId = value[0] ?? ''; // 1차 categoryId (string)
-  const secondId = value[1] ?? ''; // 2차 categoryId (string)
+  const firstId = value[0] ?? '';
+  const secondId = value[1] ?? '';
 
-  // 1) 카테고리 조회
+  // 카테고리 조회
   useEffect(() => {
     const load = async () => {
       setLoading(true);
@@ -39,15 +38,12 @@ export function SelectCategory({ value = [], onChange, id }: SelectCategoryProps
     load();
   }, []);
 
-  // 2) 1차 / 2차 리스트 계산
-  const firstCategories = categories; // 최상위 카테고리들
-
+  const firstCategories = categories;
   const secondCategories =
     firstId && categories.length > 0
       ? (categories.find((cat) => String(cat.categoryId) === firstId)?.children ?? [])
       : [];
 
-  // 3) 핸들러
   const handleFirstChange = (e: ChangeEvent<HTMLSelectElement>) => {
     const nextFirstId = e.target.value;
     // 1차만 선택된 상태로 리셋
@@ -59,12 +55,10 @@ export function SelectCategory({ value = [], onChange, id }: SelectCategoryProps
     onChange?.([firstId, nextSecondId]);
   };
 
-  // 4) 표시용 텍스트
   const firstName =
     firstId && categories.length > 0
       ? (categories.find((c) => String(c.categoryId) === firstId)?.name ?? '')
       : '';
-
   const secondName =
     secondId && secondCategories.length > 0
       ? (secondCategories.find((c) => String(c.categoryId) === secondId)?.name ?? '')

--- a/src/domains/course/components/ThumbnailUploader.tsx
+++ b/src/domains/course/components/ThumbnailUploader.tsx
@@ -41,6 +41,7 @@ export function ThumbnailUploader({
       e.currentTarget.value = '';
       setLocalPreview('');
       onFileSelect?.(null);
+      onUploadComplete?.(''); // 부모의 썸네일 상태도 비움
       return;
     }
 

--- a/src/domains/course/components/ThumbnailUploader.tsx
+++ b/src/domains/course/components/ThumbnailUploader.tsx
@@ -1,13 +1,13 @@
 'use client';
 
-import { useEffect, useState, type ChangeEvent } from 'react';
+import { useMemo, useState, type ChangeEvent } from 'react';
 import Image from 'next/image';
 import styles from './CourseForm.module.css';
 
 type ThumbnailUploaderProps = {
-  value?: string;
-  onUploadComplete?: (url: string) => void;
-  onFileSelect?: (multiFile: File | null) => void;
+  value?: string; // 부모에서 내려오는 썸네일(서버 url이든 base64든)
+  onUploadComplete?: (url: string) => void; // 부모 폼 값 갱신
+  onFileSelect?: (multiFile: File | null) => void; // 실제 파일 전달(업로드용)
 };
 
 export function ThumbnailUploader({
@@ -15,55 +15,69 @@ export function ThumbnailUploader({
   onUploadComplete,
   onFileSelect,
 }: ThumbnailUploaderProps) {
-  const [thumbnailUrl, setThumbnailUrl] = useState<string | null>(null);
+  // 로컬에서 "사용자가 방금 선택한" 미리보기만 관리 (props를 복사하지 않음)
+  const [localPreview, setLocalPreview] = useState<string>('');
 
-  useEffect(() => {
-    if (value) {
-      setThumbnailUrl(value);
-    } else {
-      setThumbnailUrl(null);
-    }
-  }, [value]);
+  // 화면에 보여줄 최종 미리보기: 로컬이 있으면 로컬, 없으면 value
+  const previewUrl = useMemo(() => localPreview || value || '', [localPreview, value]);
 
   const handleFileChange = (e: ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+    const file = e.target.files?.[0] ?? null;
 
-    onFileSelect?.(file); // 선택된 파일을 부모 컴포넌트로 전달
+    // 부모에게 파일 전달(업로드 준비)
+    onFileSelect?.(file);
+
+    // 파일 선택 취소/제거
     if (!file) {
-      setThumbnailUrl(null);
-      onUploadComplete?.('');
+      setLocalPreview('');
+      onUploadComplete?.(''); // 부모 값도 비움(원하는 정책에 따라 제거 가능)
+      return;
+    }
+
+    // 용량 제한 (5MB)
+    const maxBytes = 5 * 1024 * 1024;
+    if (file.size > maxBytes) {
+      alert('썸네일 파일은 최대 5MB까지 업로드할 수 있어요.');
+      e.currentTarget.value = '';
+      setLocalPreview('');
+      onFileSelect?.(null);
       return;
     }
 
     const reader = new FileReader();
     reader.onload = () => {
       const base64Url = String(reader.result ?? '');
-      setThumbnailUrl(base64Url);
+      setLocalPreview(base64Url);
       onUploadComplete?.(base64Url);
     };
     reader.readAsDataURL(file);
   };
 
   return (
-    <aside className={styles['upload-card']}>
-      {thumbnailUrl && (
-        <div className={styles['upload__preview']}>
-          <Image src={thumbnailUrl} alt="썸네일 미리보기" width={320} height={200} />
+    <aside className={`${styles['upload-card']} ${styles['upload-card--thumbnail']}`}>
+      <div className={styles['upload-card__item']}>
+        <input
+          id="thumbnail"
+          type="file"
+          accept="image/*"
+          onChange={handleFileChange}
+          className={styles['form__control']}
+        />
+
+        <p className={styles['upload__hint']}>
+          16:11 비율의 JPG 또는 PNG 파일(최대 5MB)을 업로드하세요.
+        </p>
+
+        <div className={styles['upload__preview']} data-has-image={previewUrl ? 'true' : 'false'}>
+          {previewUrl ? (
+            <Image src={previewUrl} alt="썸네일 미리보기" width={320} height={200} />
+          ) : (
+            <div className={styles['upload__preview-placeholder']}>
+              <span>미리보기 없음</span>
+            </div>
+          )}
         </div>
-      )}
-
-      <input
-        id="thumbnail"
-        type="file"
-        accept="image/*"
-        onChange={handleFileChange}
-        className={styles['form__control']}
-      />
-
-      <p className={styles['upload__hint']}>
-        16:11 비율의 JPG 또는 PNG 파일(최대 5MB)을 업로드하세요.
-      </p>
+      </div>
     </aside>
   );
 }

--- a/src/domains/course/constants/resource.ts
+++ b/src/domains/course/constants/resource.ts
@@ -1,36 +1,33 @@
-import { ResourceType } from '../components/ResourceUploader';
+const SIZE_MB = {
+  VIDEO: 1024, // 1GB, 해상도 720p 기준 약 10시간
+  PDF: 50, // 50MB
+  DOC: 50, // 50MB
+  ZIP: 1024, // 1GB
+} as const;
 
-export const RESOURCE_CONFIG: Record<
-  ResourceType,
-  {
-    label: string;
-    accept: string;
-    maxSizeMB: number;
-    hint: string;
-  }
-> = {
+export const RESOURCE_CONFIG = {
   VIDEO: {
     label: '동영상',
     accept: 'video/*',
-    maxSizeMB: 200,
-    hint: 'MP4, WebM 형식의 비디오를 업로드하세요 (최대 200MB 권장)',
+    maxSizeMB: SIZE_MB.VIDEO,
+    hint: `MP4 형식의 비디오를 업로드하세요 (최대 ${SIZE_MB.VIDEO}MB)`,
   },
   PDF: {
     label: 'PDF 문서',
     accept: 'application/pdf',
-    maxSizeMB: 50,
-    hint: 'PDF 파일을 업로드하세요 (최대 50MB 권장)',
+    maxSizeMB: SIZE_MB.PDF,
+    hint: `PDF 파일을 업로드하세요 (최대 ${SIZE_MB.PDF}MB)`,
   },
   DOC: {
     label: '문서 파일',
-    accept: '.doc,.docx,.txt',
-    maxSizeMB: 50,
-    hint: 'DOC, DOCX, TXT 파일을 업로드하세요 (최대 50MB 권장)',
+    accept: '.doc',
+    maxSizeMB: SIZE_MB.DOC,
+    hint: `DOC 파일을 업로드하세요 (최대 ${SIZE_MB.DOC}MB)`,
   },
   ZIP: {
     label: '압축 파일',
     accept: '.zip,.rar',
-    maxSizeMB: 100,
-    hint: 'ZIP, RAR 파일을 업로드하세요 (최대 100MB 권장)',
+    maxSizeMB: SIZE_MB.ZIP,
+    hint: `ZIP, RAR 파일을 업로드하세요 (최대 ${SIZE_MB.ZIP}MB)`,
   },
-};
+} as const;

--- a/src/domains/course/constants/resource.ts
+++ b/src/domains/course/constants/resource.ts
@@ -22,7 +22,7 @@ export const RESOURCE_CONFIG = {
     label: '문서 파일',
     accept: '.doc',
     maxSizeMB: SIZE_MB.DOC,
-    hint: `DOC 파일을 업로드하세요 (최대 ${SIZE_MB.DOC}MB)`,
+    hint: `DOC(.doc) 파일을 업로드하세요 (최대 ${SIZE_MB.DOC}MB)`,
   },
   ZIP: {
     label: '압축 파일',

--- a/src/domains/course/hooks/useCourseForm.tsx
+++ b/src/domains/course/hooks/useCourseForm.tsx
@@ -1,13 +1,12 @@
 import { useEffect, useState, type ChangeEvent, type FormEvent } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
-
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import { validateForm } from '@/shared/util/validateForm';
-
 import { buildCourseDraft, type CourseFormState } from '../utils/courseDraft';
 import { createDraftCourse } from '../services/courseCreateService';
-import { getCategories } from '../services/courseCreateService';
-import type { Category, CourseDraftForm } from '../types/course';
+import type { CourseDraftForm } from '../types/course';
+
+const COURSE_DRAFT_ID_KEY = 'courseDraftId';
 
 export function useCourseForm() {
   const router = useRouter();
@@ -29,9 +28,6 @@ export function useCourseForm() {
     price: '',
     thumbnailUrl: '',
   });
-
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [categoriesLoading, setCategoriesLoading] = useState(false);
 
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string>('');
@@ -68,6 +64,16 @@ export function useCourseForm() {
     }));
   };
 
+  const ensureDraftCreated = async (draftData: CourseDraftForm) => {
+    const savedId = sessionStorage.getItem(COURSE_DRAFT_ID_KEY);
+    if (savedId) return savedId;
+
+    // 서버에 draft 강좌 생성 → courseId 확보
+    const { courseId } = await createDraftCourse(draftData, thumbnailFile ?? undefined);
+    sessionStorage.setItem(COURSE_DRAFT_ID_KEY, courseId);
+    return courseId;
+  };
+
   const handleFormSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
 
@@ -94,10 +100,11 @@ export function useCourseForm() {
         alert('임시 저장 중 오류가 발생했습니다. 브라우저 설정을 확인해주세요.');
         return;
       }
-      // 2) 서버에 draft 강좌 생성 → courseId 확보
-      const { courseId } = await createDraftCourse(draftData, thumbnailFile ?? undefined);
 
-      // 3) URL은 create 유지
+      // 최초 1회만 임시 강좌 생성
+      await ensureDraftCreated(draftData);
+
+      // URL은 create 유지
       goStep2();
       return;
     } catch (err) {
@@ -122,21 +129,6 @@ export function useCourseForm() {
   // 카테고리 조회 + 초기 데이터 로드
   useEffect(() => {
     if (typeof window === 'undefined') return;
-
-    // 카테고리 로드
-    const loadCategories = async () => {
-      setCategoriesLoading(true);
-      try {
-        const data = await getCategories();
-        setCategories(data);
-      } catch (err) {
-        console.error('카테고리 조회 실패:', err);
-      } finally {
-        setCategoriesLoading(false);
-      }
-    };
-
-    loadCategories();
 
     // create 모드일 때 기존 draft 복원 로직 (기존 유지)
     const params = new URLSearchParams(window.location.search);
@@ -165,13 +157,12 @@ export function useCourseForm() {
     } else {
       sessionStorage.removeItem('courseDraft_step1');
       sessionStorage.removeItem('courseDraft_step2');
+      sessionStorage.removeItem(COURSE_DRAFT_ID_KEY);
     }
   }, [courseId]);
 
   return {
     formData,
-    categories,
-    categoriesLoading,
     loading,
     error,
     success,

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -362,21 +362,24 @@ export function useSectionForm(options?: UseSectionFormParams) {
 
         // 6) 기존 강의 수정
         if (lectureId && lec._dirty && !isJustCreated) {
-          const updateResource =
-            primaryResource && primaryResource.resourceType
-              ? {
-                  resourceType: primaryResource.resourceType,
-                  isDownloadable: Boolean(primaryResource.isDownloadable),
-                  fileUrl: primaryResource.fileUrl,
-                }
-              : undefined;
+          // resource 필수 계약이면 여기서 보장/가드
+          if (!primaryResource?.resourceType) {
+            // 여기로 오면 데이터가 깨진 상태라 실패시키는 게 맞음
+            throw new Error('강의 리소스가 누락되어 업데이트할 수 없습니다.');
+          }
+
+          const updateResource: LectureResource = {
+            resourceType: primaryResource.resourceType,
+            isDownloadable: Boolean(primaryResource.isDownloadable),
+            fileUrl: primaryResource.fileUrl,
+          };
 
           await updateLecture(courseId, lectureId, {
             title: lec.title,
             totalDurationSeconds: lec.duration ?? 0,
             isPreview: lec.isPreview ?? false,
             orderIndex: lIndex + 1,
-            resource: updateResource as LectureResource,
+            resource: updateResource,
           });
         }
       }

--- a/src/domains/course/hooks/useSectionForm.tsx
+++ b/src/domains/course/hooks/useSectionForm.tsx
@@ -3,23 +3,27 @@
 import { useEffect, useState } from 'react';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
-
 import type {
   CourseDraftForm,
-  CreateLectureResponse,
+  SectionDraftForm,
   LectureDraftForm,
   LectureResource,
-  SectionDraftForm,
 } from '../types/course';
 import { createEmptyLecture, createEmptySection } from '../utils/courseDraft';
 import { publishDraftCourse } from '../services/courseCreateService';
 import type { UploadResult } from '../components/ResourceUploader';
 import { deleteLecture, createLecture, updateLecture } from '../services/lectureCreateService';
 import { deleteSection, createSection, updateSection } from '../services/sectionCreateService';
-import router from 'next/router';
 
 type UseSectionFormParams = {
   courseId?: string;
+};
+
+const COURSE_DRAFT_ID_KEY = 'courseDraftId';
+
+const readDraftCourseId = () => {
+  if (typeof window === 'undefined') return '';
+  return sessionStorage.getItem(COURSE_DRAFT_ID_KEY) ?? '';
 };
 
 export function useSectionForm(options?: UseSectionFormParams) {
@@ -30,23 +34,25 @@ export function useSectionForm(options?: UseSectionFormParams) {
   const searchParams = useSearchParams();
   const entry = searchParams.get('entry');
 
-  // URL 우선, props는 fallback
-
   const [sections, setSections] = useState<SectionDraftForm[]>([createEmptySection()]);
   const [step1Data, setStep1Data] = useState<CourseDraftForm | null>(null);
+
   const [loading, setLoading] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [drafting, setDrafting] = useState(false);
+
   const [error, setError] = useState('');
   const [success, setSuccess] = useState(false);
   const [initialized, setInitialized] = useState(false);
+
+  // courseId는 "초기값"부터 sessionStorage fallback
+  const [resolvedCourseId, setResolvedCourseId] = useState<string>(() => readDraftCourseId());
 
   // === 유틸: 활성 섹션/강의만 필터링 (삭제 플래그 제외) ===
   const activeSections = sections.filter((sec) => !sec._deleted);
   const getActiveLectures = (sec: SectionDraftForm) => sec.lectures.filter((lec) => !lec._deleted);
 
-  const [resolvedCourseId, setResolvedCourseId] = useState('');
-
+  // URL/props 우선, 없으면 sessionStorage
   useEffect(() => {
     const idFromUrl = typeof params.id === 'string' ? params.id : '';
     if (idFromUrl) {
@@ -57,6 +63,12 @@ export function useSectionForm(options?: UseSectionFormParams) {
     if (courseIdProp) {
       setResolvedCourseId(courseIdProp);
       return;
+    }
+
+    // 아직도 비어있으면 세션에서 한 번 더
+    if (typeof window !== 'undefined') {
+      const saved = sessionStorage.getItem(COURSE_DRAFT_ID_KEY) ?? '';
+      if (saved) setResolvedCourseId(saved);
     }
   }, [params.id, courseIdProp]);
 
@@ -83,65 +95,72 @@ export function useSectionForm(options?: UseSectionFormParams) {
         const resourceType = primaryResource?.resourceType;
         const fileUrl = primaryResource?.fileUrl?.trim();
 
-        if (resourceType === 'VIDEO') {
-          return !videoUrl;
-        }
+        if (resourceType === 'VIDEO') return !videoUrl;
 
         if (resourceType === 'PDF' || resourceType === 'DOC' || resourceType === 'ZIP') {
           return !fileUrl;
         }
 
-        // 타입은 있는데 URL도 영상도 없다 → invalid
         return true;
       });
     });
 
   const isInvalid = structureInvalid;
 
-  // === 초기 로딩 ===
+  // 초기 로딩: courseId 여부와 상관없이 step1/step2 복원 + courseId 확보
   useEffect(() => {
     if (initialized) return;
 
     const load = async () => {
-      // courseId 없는 create 모드 → 세션에서 복원
-      if (!courseId) {
-        if (typeof window !== 'undefined') {
-          const savedStep1Data = sessionStorage.getItem('courseDraft_step1');
-          if (!savedStep1Data) {
-            alert('강좌 기본 정보가 누락되었습니다. 다시 입력해 주세요.');
-            router.replace('/courses/create?step=1');
-            return;
-          }
-          try {
-            const parsed: CourseDraftForm = JSON.parse(savedStep1Data);
-            setStep1Data(parsed);
-          } catch (err) {
-            console.error('Failed to parse saved step 1 data:', err);
-            router.replace('/courses/create?step=1');
-            return;
-          }
-
-          const savedStep2Data = sessionStorage.getItem('courseDraft_step2');
-          if (savedStep2Data) {
-            try {
-              const parsedSections: SectionDraftForm[] = JSON.parse(savedStep2Data);
-              setSections(parsedSections.length > 0 ? parsedSections : [createEmptySection()]);
-            } catch (err) {
-              console.error('Failed to parse saved step 2 data:', err);
-            }
-          }
-          setInitialized(true);
-          return;
-        }
-
-        setError('유효하지 않은 강좌 ID입니다.');
-        alert('유효하지 않은 강좌 ID입니다.');
+      if (typeof window === 'undefined') {
+        setInitialized(true);
         return;
       }
+
+      // step1 복원
+      const savedStep1Data = sessionStorage.getItem('courseDraft_step1');
+      if (!savedStep1Data) {
+        alert('강좌 기본 정보가 누락되었습니다. 다시 입력해 주세요.');
+        router.replace('/courses/create?step=1');
+        return;
+      }
+      try {
+        const parsed: CourseDraftForm = JSON.parse(savedStep1Data);
+        setStep1Data(parsed);
+      } catch (err) {
+        console.error('Failed to parse saved step 1 data:', err);
+        router.replace('/courses/create?step=1');
+        return;
+      }
+
+      // step2 복원
+      const savedStep2Data = sessionStorage.getItem('courseDraft_step2');
+      if (savedStep2Data) {
+        try {
+          const parsedSections: SectionDraftForm[] = JSON.parse(savedStep2Data);
+          setSections(parsedSections.length > 0 ? parsedSections : [createEmptySection()]);
+        } catch (err) {
+          console.error('Failed to parse saved step 2 data:', err);
+        }
+      }
+
+      // courseId 확보 (state → session)
+      const savedId = sessionStorage.getItem(COURSE_DRAFT_ID_KEY) ?? '';
+      const finalId = courseId || savedId;
+
+      if (!finalId) {
+        alert('유효한 강좌 ID를 찾을 수 없습니다. 다시 시도해 주세요.');
+        router.replace('/courses/create?step=1');
+        return;
+      }
+
+      if (finalId !== courseId) setResolvedCourseId(finalId);
+
+      setInitialized(true);
     };
 
     load();
-  }, [courseId, router, initialized]);
+  }, [initialized, router, courseId]);
 
   // === 공통 헬퍼: 섹션/강의 업데이트 ===
   const updateSectionByLocalId = (
@@ -172,7 +191,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
   };
 
   // === 섹션/강의 조작 핸들러들 (로컬 상태만) ===
-
   const handleSectionAdd = () => {
     setSections((prev) => [...prev, createEmptySection()]);
   };
@@ -238,21 +256,19 @@ export function useSectionForm(options?: UseSectionFormParams) {
       };
 
       const nextDuration = isVideo && result.duration != null ? result.duration : lecture.duration;
-
-      const nextVideoUrl = isVideo ? result.fileUrl : lecture.videoUrl;
+      const nextVideoUrl = isVideo ? (result.previewUrl ?? result.fileUrl) : lecture.videoUrl;
 
       return {
         ...lecture,
         duration: nextDuration,
         videoUrl: nextVideoUrl,
         resource: [newResource],
-        // 파일이 전달된 경우에만 덮어쓰고, 없으면 기존 값을 유지
         _file: result.multiFile ?? lecture.file ?? null,
       };
     });
   };
 
-  // 발행하기 버튼 => 섹션 생성 , 섹션 수정, 강의 생성, 강의 수정, 삭제 한번에 처리 ===
+  // === 발행하기: 섹션/강의 생성/수정/삭제 반영 ===
   const syncSectionsAndLectures = async (courseId: string) => {
     for (let sIndex = 0; sIndex < sections.length; sIndex++) {
       const sec = sections[sIndex];
@@ -270,19 +286,15 @@ export function useSectionForm(options?: UseSectionFormParams) {
           if (!lec.title.trim()) return false;
 
           const resources = lec.resource ?? [];
-
           const primaryResource: LectureResource | undefined = Array.isArray(resources)
             ? resources[0]
             : undefined;
 
           const videoUrl = lec.videoUrl?.trim();
-
           const resourceType = primaryResource?.resourceType;
-
           const fileUrl = primaryResource?.fileUrl?.trim();
 
           if (resourceType === 'VIDEO') return !!videoUrl;
-
           if (resourceType === 'PDF' || resourceType === 'DOC' || resourceType === 'ZIP')
             return !!fileUrl;
 
@@ -293,19 +305,13 @@ export function useSectionForm(options?: UseSectionFormParams) {
 
       // 2) 섹션 생성
       if (!sectionId && hasContent) {
-        const created = await createSection(courseId, {
-          title: sec.title,
-          orderIndex: sIndex + 1,
-        });
+        const created = await createSection(courseId, { title: sec.title, orderIndex: sIndex + 1 });
         sectionId = String(created.sectionId);
       }
 
       // 3) 섹션 수정
       if (sectionId && sec._dirty) {
-        await updateSection(courseId, sectionId, {
-          title: sec.title,
-          orderIndex: sIndex + 1,
-        });
+        await updateSection(courseId, sectionId, { title: sec.title, orderIndex: sIndex + 1 });
       }
 
       if (!sectionId) continue;
@@ -320,7 +326,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
           continue;
         }
 
-        // 데이터 준비 (판독 결과 변수화)
         const resources = lec.resource ?? [];
         const primaryResource: LectureResource | undefined = Array.isArray(resources)
           ? resources[0]
@@ -330,14 +335,13 @@ export function useSectionForm(options?: UseSectionFormParams) {
         let lectureId = lec.id ? String(lec.id) : undefined;
         let isJustCreated = false;
 
-        // 5) 새 강의 생성 로직
+        // 5) 새 강의 생성
         if (!lectureId && lec.title.trim()) {
           const createPayload = {
             title: lec.title,
             totalDurationSeconds: lec.duration ?? 0,
             isPreview: lec.isPreview ?? false,
             orderIndex: lIndex + 1,
-            // 생성 시에는 리소스를 [배열]로 전달
             resource:
               primaryResource && primaryResource.resourceType
                 ? [
@@ -350,16 +354,14 @@ export function useSectionForm(options?: UseSectionFormParams) {
                 : undefined,
           };
 
+          // TODO: 현재 강의 생성 API 동작 X. 추후 명세 따라 수정 필요
           const created = await createLecture(courseId, sectionId, createPayload, file);
-
-          // 생성 직후 ID 업데이트 및 플래그 설정
           lectureId = String(created.lectureId ?? created.lectureId);
           isJustCreated = true;
         }
 
-        // 6) 기존 강의 수정 로직 (방금 만든 게 아닐 때만 실행)
+        // 6) 기존 강의 수정
         if (lectureId && lec._dirty && !isJustCreated) {
-          // 수정 시에는 리소스를 {객체}로 전달 (API 명세 준수)
           const updateResource =
             primaryResource && primaryResource.resourceType
               ? {
@@ -374,8 +376,7 @@ export function useSectionForm(options?: UseSectionFormParams) {
             totalDurationSeconds: lec.duration ?? 0,
             isPreview: lec.isPreview ?? false,
             orderIndex: lIndex + 1,
-            // @ts-ignore: API 정의가 단일 객체이므로 가공된 객체 전달
-            resource: updateResource,
+            resource: updateResource as LectureResource,
           });
         }
       }
@@ -398,7 +399,9 @@ export function useSectionForm(options?: UseSectionFormParams) {
       return;
     }
 
-    if (!courseId) {
+    // 최종적으로도 세션 fallback 한 번 더
+    const finalCourseId = courseId || readDraftCourseId();
+    if (!finalCourseId) {
       alert('유효한 강좌 ID를 찾을 수 없습니다. 다시 시도해 주세요.');
       return;
     }
@@ -408,18 +411,18 @@ export function useSectionForm(options?: UseSectionFormParams) {
     setSubmitting(true);
 
     try {
-      // 1) 섹션/강의 생성/수정/삭제 한 번에 반영
-      await syncSectionsAndLectures(courseId);
-
-      // 2) 강좌 발행
-      await publishDraftCourse(courseId);
+      // TODO: 현재 강의 생성 API 동작 X. 추후 명세 따라 수정 필요
+      await syncSectionsAndLectures(finalCourseId);
+      await publishDraftCourse(finalCourseId);
 
       alert('강좌가 발행되었습니다.');
       setSuccess(true);
+
       sessionStorage.removeItem('courseDraft_step1');
       sessionStorage.removeItem('courseDraft_step2');
+      sessionStorage.removeItem(COURSE_DRAFT_ID_KEY);
 
-      router.replace(`/courses/${courseId}`);
+      router.replace(`/courses/${finalCourseId}`);
     } catch (err) {
       console.error(err);
       setError(err instanceof Error ? err.message : '강좌 등록 중 오류가 발생했습니다.');
@@ -432,7 +435,6 @@ export function useSectionForm(options?: UseSectionFormParams) {
     const params = new URLSearchParams();
     params.set('step', '1');
     if (entry) params.set('entry', entry);
-
     router.push(`/courses/create?${params.toString()}&from=section`);
   };
 
@@ -448,9 +450,25 @@ export function useSectionForm(options?: UseSectionFormParams) {
     sessionStorage.setItem('courseDraft_step2', JSON.stringify(sections));
   }, [sections, initialized]);
 
+  const handleLectureRemoveResource = (sectionLocalId: string, lectureLocalId: string) => {
+    updateLectureByLocalId(sectionLocalId, lectureLocalId, (lec) => {
+      const primary = lec.resource?.[0];
+      const wasVideo = primary?.resourceType === 'VIDEO';
+
+      return {
+        ...lec,
+        _dirty: true,
+        resource: [] as LectureResource[], // 리소스 제거
+        ...(wasVideo ? { videoUrl: '', duration: 0 } : {}), // VIDEO였던 경우 영상 관련도 제거
+        file: undefined, // 업로드 파일 제거
+        _file: null,
+      };
+    });
+  };
+
   return {
     user,
-    sections: activeSections, // 삭제된 건 UI에서 숨김
+    sections: activeSections,
     step1Data,
     loading,
     submitting,
@@ -465,6 +483,7 @@ export function useSectionForm(options?: UseSectionFormParams) {
     handleSectionTitleChange,
     handleLectureTitleChange,
     handleLectureUpload,
+    handleLectureRemoveResource,
     handleFinalSubmit,
     handlePrevStep,
     handleCancel,

--- a/src/domains/course/pages/CourseCreateClientPage.tsx
+++ b/src/domains/course/pages/CourseCreateClientPage.tsx
@@ -1,15 +1,20 @@
 'use client';
 
-import { useParams, useSearchParams } from 'next/navigation';
+import { useSearchParams } from 'next/navigation';
 import styles from '@/app/courses/create/CourseCreatePage.module.css';
 import { SectionForm } from '@/domains/course/components/SectionForm';
 import { CourseForm } from '../components/CourseForm';
 
 export default function CourseCreateClientPage() {
   const searchParams = useSearchParams();
-  const { id } = useParams<{ id: string }>();
-  const courseId = id;
   const currentStep = searchParams.get('step') || '1';
+  const stepNumber = Number(currentStep);
+
+  const getStepClass = (step: number) => {
+    if (stepNumber === step) return styles['course-create__step--active'];
+    if (stepNumber > step) return styles['course-create__step--complete'];
+    return '';
+  };
 
   const renderContent = () => {
     switch (currentStep) {
@@ -27,9 +32,30 @@ export default function CourseCreateClientPage() {
       aria-labelledby="course-create-title"
     >
       <header className={styles['course-create__header']}>
-        <h1 id="course-create-title" className={styles['course-create__title']}>
-          강좌 등록 (Step {currentStep})
-        </h1>
+        <div className={styles['course-create__heading']}>
+          <h1 id="course-create-title" className={styles['course-create__title']}>
+            강좌 등록
+          </h1>
+          <p className={styles['course-create__subtitle']}>
+            강좌 기본 정보와 커리큘럼을 순서대로 입력해 주세요.
+          </p>
+        </div>
+        <ol className={styles['course-create__steps']} aria-label="강좌 등록 단계">
+          <li
+            className={`${styles['course-create__step']} ${getStepClass(1)}`}
+            aria-current={stepNumber === 1 ? 'step' : undefined}
+          >
+            <span className={styles['course-create__step-number']}>1</span>
+            <span className={styles['course-create__step-text']}>기본 정보</span>
+          </li>
+          <li
+            className={`${styles['course-create__step']} ${getStepClass(2)}`}
+            aria-current={stepNumber === 2 ? 'step' : undefined}
+          >
+            <span className={styles['course-create__step-number']}>2</span>
+            <span className={styles['course-create__step-text']}>섹션 구성</span>
+          </li>
+        </ol>
       </header>
       <div className={styles['course-create__body']}>{renderContent()}</div>
     </section>

--- a/src/domains/course/services/courseCreateService.ts
+++ b/src/domains/course/services/courseCreateService.ts
@@ -1,3 +1,4 @@
+import { getApi, patchApi, postApi } from '@/shared/lib/api/fetchApi';
 import type {
   CourseDraftForm,
   SectionDraftForm,
@@ -6,7 +7,6 @@ import type {
   GetDraftCourseResponse,
 } from '../types/course';
 
-import { getApi, patchApi, postApi } from '@/shared/lib/api/fetchApi';
 import {
   applySectionDraftsForNewCourse,
   createCourseFormData,
@@ -14,7 +14,7 @@ import {
   mapResponseToCourseDraft,
 } from '../utils/courseCreate';
 
-// 강좌생성 API 호출
+// 강좌 임시 생성 API
 export const createDraftCourse = async (
   draftData: CourseDraftForm,
   thumbnailFile?: File,
@@ -29,7 +29,7 @@ export const createDraftCourse = async (
   });
 };
 
-// 강좌 발행 API 호출
+// 강좌 발행 API
 export const publishDraftCourse = async (courseId: string): Promise<void> => {
   return await patchApi<void>(`/api/instructor/courses/${courseId}/publish`);
 };
@@ -56,6 +56,7 @@ export const createCourse = async (
 
 // 카테고리 조회 API
 export const getCategories = async (): Promise<Category[]> => {
+  // TODO: 임시 목업 데이터, 카테고리 조회 API 완성되면 제거
   if (process.env.NODE_ENV === 'development') {
     return [
       {
@@ -96,15 +97,13 @@ export const updateDraftCourse = async (
       body: formData,
       credentials: 'include',
     });
-
-    // 보통 수정 API는 body가 없거나 {status, code, message} 정도만 반환하므로 따로 파싱 안 해도 됨
   } catch (err) {
     console.error('updateDraftCourse 실패:', err);
     throw err instanceof Error ? err : new Error('강좌 수정 중 오류가 발생했습니다.');
   }
 };
 
-// 임시 생성된 강좌 조회API
+// 임시 생성된 강좌 조회 API
 export async function getDraftCourse(courseId: string): Promise<{
   courseDraft: CourseDraftForm;
   sectionDrafts: SectionDraftForm[];

--- a/src/shared/lib/api/fetchApi.ts
+++ b/src/shared/lib/api/fetchApi.ts
@@ -57,7 +57,7 @@ export async function fetchApi<T = unknown>(
       // 만약 응답이 401 (리프레시 토큰 만료)일 경우 -> 재로그인
       if (response.status === 401) {
         cookieStore.delete('accessToken'); // 제로그인
-        cookieStore.delete('refreshToken'); //
+        cookieStore.delete('refreshToken');
         console.error('리프레시 토큰이 만료되었습니다. 다시 로그인이 필요합니다.');
       }
 

--- a/src/shared/lib/api/fetchApi.ts
+++ b/src/shared/lib/api/fetchApi.ts
@@ -1,4 +1,5 @@
 'use server';
+
 import { cookies } from 'next/headers';
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
 export type ApiResponse<T = unknown> = {
@@ -35,18 +36,10 @@ export async function fetchApi<T = unknown>(
     // JSON 요청일 때만 Content-Type 기본 부여
     if (!isFormData) {
       const hasContentType = headers.get('Content-Type');
-      if (!hasContentType) headers.append('Content-Type', 'application/json');
-    }
-
-    // JSON 요청일 때만 Content-Type 기본 부여
-    if (!isFormData) {
-      const hasContentType = Object.keys(headers).some((k) => k.toLowerCase() === 'content-type');
-      if (!hasContentType) headers['Content-Type'] = 'application/json';
+      if (!hasContentType) headers.set('Content-Type', 'application/json');
     } else {
       // FormData면 Content-Type을 절대 직접 넣지 않음 (boundary 자동 설정 필요)
-      for (const k of Object.keys(headers)) {
-        if (k.toLowerCase() === 'content-type') delete headers[k];
-      }
+      headers.delete('Content-Type');
     }
     const url = endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`;
 
@@ -63,8 +56,9 @@ export async function fetchApi<T = unknown>(
     if (!response.ok) {
       // 만약 응답이 401 (리프레시 토큰 만료)일 경우 -> 재로그인
       if (response.status === 401) {
-        cookieStore.delete('accessToken'); // 재로그인
-        throw new Error('리프레시 토큰이 만료되었습니다. 다시 로그인이 필요합니다.');
+        cookieStore.delete('accessToken'); // 제로그인
+        cookieStore.delete('refreshToken'); //
+        console.error('리프레시 토큰이 만료되었습니다. 다시 로그인이 필요합니다.');
       }
 
       throw new Error(`[${response.status} (${resJson.code}) - ${resJson.message}]`);
@@ -99,6 +93,7 @@ export async function fetchApi<T = unknown>(
 export async function getApi<T = unknown>(endpoint: string, options: RequestInit = {}): Promise<T> {
   return fetchApi<T>(endpoint, { method: 'GET', ...options });
 }
+
 /**
  * POST 요청을 위한 fetchApi wrapper
  *
@@ -116,6 +111,7 @@ export async function postApi<T = unknown>(
     ...options,
   });
 }
+
 /**
  * PUT 요청을 위한 fetchApi wrapper
  *
@@ -133,6 +129,7 @@ export async function putApi<T = unknown>(
     ...options,
   });
 }
+
 /**
  * DELETE 요청을 위한 fetchApi wrapper
  *
@@ -144,6 +141,7 @@ export async function deleteApi<T = unknown>(
 ): Promise<T> {
   return fetchApi<T>(endpoint, { method: 'DELETE', ...options });
 }
+
 /**
  * PATCH 요청을 위한 fetchApi wrapper
  *

--- a/src/shared/lib/api/fetchApi.ts
+++ b/src/shared/lib/api/fetchApi.ts
@@ -56,7 +56,7 @@ export async function fetchApi<T = unknown>(
     if (!response.ok) {
       // 만약 응답이 401 (리프레시 토큰 만료)일 경우 -> 재로그인
       if (response.status === 401) {
-        cookieStore.delete('accessToken'); // 제로그인
+        cookieStore.delete('accessToken'); // 재로그인
         cookieStore.delete('refreshToken');
         console.error('리프레시 토큰이 만료되었습니다. 다시 로그인이 필요합니다.');
       }


### PR DESCRIPTION
## 변경 사항

* 리소스 업로드/삭제 흐름 전반 정리
  * ResourceUploader / ThumbnailUploader: draft 상태 분리 및 `previewUrl` 연동
  * 리소스 용량 표기(SIZE_MB) 일원화 및 초과 입력 방지 로직 추가
  * 리소스 삭제 로직 개선 (`handleLectureRemoveResource` 추가)
* 강좌 생성/임시 저장 플로우 안정화
  * 임시 강좌 최초 1회만 생성되도록 개선
  * 임시 강좌 생성 시 `draftId` 저장
  * 불필요한 카테고리 조회 API 연동 제거
* 폼 및 UI 구조 정리
  * SectionForm: 섹션 토글 기능 추가
  * CourseForm / 강좌 생성 페이지: 스타일 및 레이아웃 정리
  * 스타일 헬퍼 추가 (`getStepClass`, `stepNumber`)
* fetchApi 예외 처리 개선
  * 헤더 타입 오류 해결
  * 리프레시 토큰 만료 시 throw 대신 `console.error` 처리
* 코드 품질 개선
  * 불필요한 state / hook / 주석 제거
  * `TODO:` 주석 추가 및 리팩터링 대상 명시

## 리뷰 필요

* 서버 이슈로 임시 강의 생성 / 강좌 발행 / 카테고리 조회는 연동 테스트에서 제외했습니다.
* 따라서 이번 리뷰는 아래 변경 사항 위주로 확인 부탁드립니다.
  * CourseForm / SectionForm UI 및 상태 관리 변경
  * ResourceUploader / ThumbnailUploader 로직(프리뷰/용량 제한/리소스 삭제 핸들러) 정합성

### 📌 앞으로의 개발 가이드

* `TODO:`가 붙은 부분은 **API 구조 개선 또는 후속 리팩터링 대상**입니다.
* 이후 리팩터링이 필요한 코드에는 `TODO:`를 명시적으로 남겨주세요.
