### PR TITLE
feat: 장바구니 담기/제거 플로우 연결

### DIFF
--- a/src/domains/cart/pages/CartClientPage.tsx
+++ b/src/domains/cart/pages/CartClientPage.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { CartItem as CartItemType } from '@/domains/cart/types/cart';
@@ -9,18 +9,25 @@ import { CartItem } from '@/domains/cart/components/CartItem';
 import { preparePayment } from '@/domains/cart/services/cartService';
 import { getCourseDetail } from '@/domains/course/services/courseService';
 import styles from '@/app/cart/CartPage.module.css';
+import { MOCK_GET_COURSE_DETAIL } from '@/mocks/course.mock';
 import type { PreparePaymentResponse } from '../types/cart';
 import { useTossPayment } from '../hooks/useTossPayment';
 
 export function CartClientPage() {
   const searchParams = useSearchParams();
   const initialCourseId = searchParams.get('courseId');
+
   const [items, setItems] = useState<CartItemType[]>([]);
   const [selectedMap, setSelectedMap] = useState<Record<string, boolean>>({});
   const [paymentPayload, setPaymentPayload] = useState<PreparePaymentResponse | null>(null);
 
+  const [cartLoading, setCartLoading] = useState(false);
+  const [cartMutating, setCartMutating] = useState(false);
+
+  const handledInitialCourseIdRef = useRef<string | null>(null);
+
   const selectedItems = useMemo(
-    () => items.filter((item) => selectedMap[item.id]),
+    () => items.filter((item) => selectedMap[String(item.id)]),
     [items, selectedMap],
   );
 
@@ -28,86 +35,191 @@ export function CartClientPage() {
   const finalPrice = selectedItems.reduce((sum, item) => sum + item.price, 0);
   const discountPrice = totalPrice - finalPrice;
   const canCheckout = selectedItems.length > 0;
-  const isAllSelected = items.length > 0 && selectedItems.length === items.length;
   const hasItems = items.length > 0;
-  const canSubmit = canCheckout;
+  const isAllSelected = items.length > 0 && selectedItems.length === items.length;
+
+  // 결제 payload가 최신 선택 기준인지 간단 가드(선택)
+  const canSubmit =
+    canCheckout && !!paymentPayload?.orderId && paymentPayload.amount === finalPrice;
+
+  const refetchCart = async () => {
+    setCartLoading(true);
+    try {
+      // TODO: 장바구니 조회 API 연동
+
+      const courseIds: string[] = []; // TODO: 장바구니 조회 API 연동 후 교체
+
+      const details = await Promise.all(courseIds.map((id) => getCourseDetail(id)));
+
+      const mappedItems = details.filter(Boolean).map((detail) => ({
+        id: Number(detail.courseId),
+        title: detail.title,
+        instructor: detail.instructor?.name ?? '강사',
+        price: detail.price,
+        originalPrice: detail.price,
+        thumbnailUrl: detail.thumbnailUrl,
+      })) as CartItemType[];
+
+      setItems(mappedItems);
+      setSelectedMap(
+        Object.fromEntries(mappedItems.map((item) => [String(item.id), true])) as Record<
+          string,
+          boolean
+        >,
+      );
+    } catch (e) {
+      console.error('장바구니 목록 조회에 실패했습니다.', e);
+    } finally {
+      setCartLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    // TODO: 장바구니 조회 API 연동 후 호출
+    // void refetchCart();
+  }, []);
+
+  useEffect(() => {
+    if (!initialCourseId) return;
+
+    if (handledInitialCourseIdRef.current === initialCourseId) return;
+    handledInitialCourseIdRef.current = initialCourseId;
+
+    (async () => {
+      setCartMutating(true);
+      try {
+        // TODO: 장바구니 담기 API 연동 (추가/수정/삭제가 같은 API일 수도 있음)
+
+        // TODO: 장바구니 조회 API 연동 후 교체 및 refetchCart() 호출
+        const detail = MOCK_GET_COURSE_DETAIL;
+
+        if (detail) {
+          const mapped: CartItemType = {
+            id: Number(detail.courseId),
+            title: detail.title,
+            instructor: detail.instructor?.name ?? '강사',
+            price: detail.price,
+            originalPrice: detail.price,
+            thumbnailUrl: detail.thumbnailUrl,
+          };
+
+          setItems((prev) =>
+            prev.some((x) => String(x.id) === String(mapped.id)) ? prev : [...prev, mapped],
+          );
+
+          setSelectedMap((prev) => ({
+            ...prev,
+            [String(mapped.id)]: true,
+          }));
+        }
+        // await refetchCart();
+
+        setSelectedMap((prev) => ({
+          ...prev,
+          [String(initialCourseId)]: true,
+        }));
+      } catch (e) {
+        console.error('장바구니 담기(추가) 처리에 실패했습니다.', e);
+      } finally {
+        setCartMutating(false);
+      }
+    })();
+  }, [initialCourseId]);
 
   const handleSelectChange = (id: number, checked: boolean) => {
     setSelectedMap((prev) => ({
       ...prev,
-      [id]: checked,
+      [String(id)]: checked,
     }));
   };
 
   const handleSelectAll = (checked: boolean) => {
     setSelectedMap(
-      () => Object.fromEntries(items.map((item) => [item.id, checked])) as Record<string, boolean>,
+      () =>
+        Object.fromEntries(items.map((item) => [String(item.id), checked])) as Record<
+          string,
+          boolean
+        >,
     );
   };
 
   const handleDeleteSelected = () => {
     if (!canCheckout) return;
-    setItems((prev) => {
-      const remaining = prev.filter((item) => !selectedMap[item.id]);
-      setSelectedMap(
-        Object.fromEntries(remaining.map((item) => [item.id, true])) as Record<string, boolean>,
-      );
-      return remaining;
-    });
+
+    const deleteIds = new Set(selectedItems.map((it) => String(it.id)));
+
+    (async () => {
+      setCartMutating(true);
+      try {
+        // TODO: 장바구니 취소(제거) API 연동 (추가/수정/삭제가 같은 API일 수도 있음)
+
+        setItems((prev) => {
+          const remaining = prev.filter((item) => !deleteIds.has(String(item.id)));
+          setSelectedMap(
+            Object.fromEntries(remaining.map((item) => [String(item.id), true])) as Record<
+              string,
+              boolean
+            >,
+          );
+          return remaining;
+        });
+      } catch (e) {
+        console.error('장바구니 제거에 실패했습니다.', e);
+      } finally {
+        setCartMutating(false);
+      }
+    })();
   };
 
-  const handleCheckoutClick = async () => {
-    if (!canCheckout) return;
-    const firstTitle = selectedItems[0]?.title ?? '강좌';
-    const orderName =
-      selectedItems.length > 1 ? `${firstTitle} 외 ${selectedItems.length - 1}건` : firstTitle;
-
-    if (paymentPayload && paymentPayload.amount && handlePay) {
-      await handlePay(paymentPayload.amount, orderName);
-    }
-  };
+  // 선택된 아이템이 바뀔 때마다 결제 준비 요청
+  const selectedKey = useMemo(
+    () =>
+      selectedItems
+        .map((it) => String(it.id))
+        .sort()
+        .join(','),
+    [selectedItems],
+  );
 
   useEffect(() => {
-    if (!initialCourseId) return;
+    if (!canCheckout) {
+      setPaymentPayload(null);
+      return;
+    }
+
+    let cancelled = false;
 
     (async () => {
       try {
-        const [detail, prepared] = await Promise.all([
-          getCourseDetail(initialCourseId),
-          preparePayment({ items: [{ courseId: Number(initialCourseId) }] }),
-        ]);
-        if (!detail) return;
-
-        const mappedItem: CartItemType = {
-          id: Number(detail.courseId),
-          title: detail.title,
-          instructor: detail.instructor?.name ?? '강사',
-          price: detail.price,
-          originalPrice: detail.price,
-          thumbnailUrl: detail.thumbnailUrl,
-        };
-
-        setItems((prev) => {
-          if (prev.some((item) => item.id === mappedItem.id)) return prev;
-          return [...prev, mappedItem];
+        const prepared = await preparePayment({
+          items: selectedItems.map((it) => ({ courseId: Number(it.id) })),
         });
-
-        setSelectedMap((prev) => ({
-          ...prev,
-          [mappedItem.id]: true,
-        }));
-
+        if (cancelled) return;
         setPaymentPayload(prepared);
       } catch (error) {
         console.error('결제 준비 요청에 실패했습니다.', error);
       }
     })();
-  }, [initialCourseId]);
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedKey, canCheckout]);
 
   const { handlePay } = useTossPayment({
     orderId: paymentPayload?.orderId ?? '',
     amount: paymentPayload?.amount ?? 0,
   });
+
+  const handleCheckoutClick = async () => {
+    if (!canSubmit) return;
+
+    const firstTitle = selectedItems[0]?.title ?? '강좌';
+    const orderName =
+      selectedItems.length > 1 ? `${firstTitle} 외 ${selectedItems.length - 1}건` : firstTitle;
+
+    await handlePay(paymentPayload!.amount, orderName);
+  };
 
   return (
     <main className={`${styles['cart-page']} app-shell`}>
@@ -121,6 +233,7 @@ export function CartClientPage() {
                     type="checkbox"
                     checked={isAllSelected}
                     onChange={(event) => handleSelectAll(event.target.checked)}
+                    disabled={cartLoading || cartMutating}
                   />
                   <span>전체 선택</span>
                 </label>
@@ -128,7 +241,7 @@ export function CartClientPage() {
                   type="button"
                   className={styles['cart-page__remove-selected']}
                   onClick={handleDeleteSelected}
-                  disabled={!canCheckout}
+                  disabled={!canCheckout || cartLoading || cartMutating}
                 >
                   선택 삭제
                 </button>
@@ -140,14 +253,16 @@ export function CartClientPage() {
                   <CartItem
                     key={item.id}
                     item={item}
-                    checked={Boolean(selectedMap[item.id])}
-                    onSelectChange={(checked) => handleSelectChange(item.id, checked)}
+                    checked={Boolean(selectedMap[String(item.id)])}
+                    onSelectChange={(checked) => handleSelectChange(Number(item.id), checked)}
                   />
                 ))}
               </ul>
             ) : (
               <div className={styles['cart-page__empty']}>
-                <p className={styles['cart-page__empty-text']}>담긴 강좌가 없습니다.</p>
+                <p className={styles['cart-page__empty-text']}>
+                  {cartLoading ? '장바구니 불러오는 중...' : '담긴 강좌가 없습니다.'}
+                </p>
                 <Link href="/" className={styles['cart-page__empty-action']}>
                   강좌 보러가기
                 </Link>
@@ -185,8 +300,8 @@ export function CartClientPage() {
           id="payment-button"
           className={styles['cart-page__cta-button']}
           type="button"
-          disabled={!canSubmit}
-          aria-disabled={!canSubmit}
+          disabled={!canSubmit || cartLoading || cartMutating}
+          aria-disabled={!canSubmit || cartLoading || cartMutating}
           onClick={handleCheckoutClick}
         >
           결제하기

--- a/src/domains/course/components/FloatingCTA.tsx
+++ b/src/domains/course/components/FloatingCTA.tsx
@@ -8,30 +8,37 @@ export type FloatingCTAProps = {
   price: number;
   isFree: boolean;
   isEnrolled: boolean;
-  onApply: () => void;
   isOwner: boolean;
+
+  isInCart?: boolean;
+  cartPending?: boolean;
+
+  onApply: () => void;
+  onAddToCart?: () => void;
 
   instructorName: string;
   totalLectures: number;
   totalTime: string;
   level: CourseLevel;
-
-  onAddToCart?: () => void;
 };
 
 export const FloatingCTA = ({
   price,
   isFree,
   isEnrolled,
-  onApply,
   isOwner,
+  isInCart = false,
+  cartPending = false,
+  onApply,
+  onAddToCart,
   instructorName,
   totalLectures,
   totalTime,
   level,
-  onAddToCart,
 }: FloatingCTAProps) => {
   const primaryLabel = isOwner ? '내가 등록한 강좌' : isEnrolled ? '학습하기' : '수강신청하기';
+
+  const showAddToCartButton = !isFree && !isEnrolled && !isOwner && !isInCart && !!onAddToCart;
 
   return (
     <aside className={styles['floating-cta']} aria-label="강좌 신청 플로팅 영역">
@@ -54,11 +61,13 @@ export const FloatingCTA = ({
             {primaryLabel}
           </button>
 
-          {!isFree && !isEnrolled && !isOwner && onAddToCart && (
+          {showAddToCartButton && (
             <button
               type="button"
               className={styles['floating-cta__secondary']}
               onClick={onAddToCart}
+              disabled={cartPending}
+              aria-disabled={cartPending}
             >
               장바구니 담기
             </button>

--- a/src/domains/course/hooks/useCourseDetail.tsx
+++ b/src/domains/course/hooks/useCourseDetail.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { MOCK_GET_COURSE_DETAIL } from '@/mocks/course.mock';
 import { getCourseDetail } from '../services/courseService';
 import type {
   CourseDetail,
@@ -25,7 +26,11 @@ export function useCourseDetail(courseId: string) {
       try {
         setLoading(true);
 
-        const courseDetailResponse: GetCourseDetailResponse = await getCourseDetail(courseId);
+        // TODO: API 정상화 후 제거 또는 MSW로 전환
+        const courseDetailResponse: GetCourseDetailResponse =
+          process.env.NODE_ENV === 'development'
+            ? MOCK_GET_COURSE_DETAIL
+            : await getCourseDetail(courseId);
 
         // 1) CourseDetail.course 매핑 (API 응답 → Course 도메인)
         const course: Course = {

--- a/src/domains/course/pages/CourseDetailClientPage.tsx
+++ b/src/domains/course/pages/CourseDetailClientPage.tsx
@@ -30,12 +30,15 @@ export default function CourseDetailClientPage() {
   const { user, setUser } = useAuthState();
 
   const [activeTab, setActiveTab] = useState<TabKey>('intro');
+  const [cartPending, setCartPending] = useState(false);
 
   const loginModal = useModal(false);
   const applyModal = useModal(false);
 
   const { course, sections, lectures, loading } = useCourseDetail(id);
   const { isEnrolled, applying, handleApply } = useCourseApply(user, id);
+
+  const isInCart = !!user?.cart?.includes(id);
 
   if (loading) {
     return <div className={styles.loading}>로딩 중...</div>;
@@ -68,14 +71,29 @@ export default function CourseDetailClientPage() {
       loginModal.open();
       return;
     }
+    if (cartPending) return;
+
+    if (isInCart) {
+      const go = confirm('이미 장바구니에 담긴 강좌예요. 장바구니로 이동할까요?');
+      if (go) router.push(`/cart?courseId=${id}`);
+      return;
+    }
+
+    setCartPending(true);
     try {
+      // TODO: 장바구니 담기 API 연동 - await addToCart(...) 호출
       setUser({
         ...user,
-        cart: user.cart.includes(id) ? user.cart : [...user.cart, id],
+        cart: [...(user.cart ?? []), id],
       });
       // toast.success('장바구니에 담았어요');
+      const go = confirm('장바구니에 담았어요. 장바구니로 이동할까요?');
+      if (go) router.push(`/cart?courseId=${id}`);
     } catch {
       // toast.error('장바구니 담기에 실패했어요');
+      alert('장바구니 담기에 실패했어요');
+    } finally {
+      setCartPending(false);
     }
   };
 
@@ -191,6 +209,8 @@ export default function CourseDetailClientPage() {
           price={course.price}
           isFree={course.isFree}
           isEnrolled={isEnrolled}
+          isInCart={isInCart}
+          cartPending={cartPending}
           onApply={handleApplyClick}
           onAddToCart={handleAddToCartClick}
           isOwner={isOwner}

--- a/src/domains/course/pages/CourseListClientPage.tsx
+++ b/src/domains/course/pages/CourseListClientPage.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import styles from '@/app/CourseListPage.module.css';
+import { MOCK_GET_ALL_COURSE } from '@/mocks/course.mock';
 import { CourseCard } from '../components/CourseCard';
 import { getAllCourses } from '../services/courseService';
 import type { CourseCardType, GetAllCourseResponse } from '../types/course';
@@ -18,7 +19,9 @@ export default function CourseListClientPage() {
   useEffect(() => {
     const fetchCourses = async () => {
       try {
-        const data: GetAllCourseResponse = await getAllCourses();
+        // TODO: API 정상화 후 제거 또는 MSW로 전환
+        const data: GetAllCourseResponse =
+          process.env.NODE_ENV === 'development' ? MOCK_GET_ALL_COURSE : await getAllCourses();
 
         const courseCardData: CourseCardType[] = data.content.map((item) => ({
           id: item.courseId,


### PR DESCRIPTION
## 변경 사항

- 강좌 상세 페이지에서 장바구니 담기 플로우 연결
  - 중복 클릭 방지(cartPending) + 담기 성공/이미 담김 시 confirm 피드백(임시)
- 장바구니 담김 여부에 따른 CTA 정책 적용
  - 미담김: `장바구니 담기`
  - 담김: `수강신청`으로 전환 + 담기 액션 가드
- 결제 및 장바구니 페이지(`/cart`)에서 선택 삭제로 “담기 취소” 가능
  - 삭제/로딩 중 버튼 disabled 처리(cartMutating)
  - **TODO:** 장바구니 조회 API 연동 후 `/cart` 진입 시 `refetchCart()`로
    서버 장바구니 목록 기반 items/selectedMap 세팅하도록 보완 예정
- 개발 환경에서 강좌 목록/상세 API 목업 폴백 추가
  - `NODE_ENV=development`일 때 목업 데이터로 분기 처리
  - TODO: API 정상화 후 제거/MSW 전환 주석 추가

## 리뷰 필요

- **헤더 장바구니 버튼으로 바로 진입했을 때(/cart 단독 진입) 흐름은 현재 개발 환경에서 검증이 어렵습니다.**
  - 현재 장바구니 데이터는 장바구니 조회 API 대신, 상세 페이지에서 “담기” 액션으로만 로컬 상태가 갱신되는 구조입니다.
  - 따라서 `/cart?courseId=...` 진입(상세 → 장바구니 이동) 시에는 동작하지만, 헤더에서 `/cart`로 바로 진입하면(쿼리 없음) 장바구니 조회 API 미연동 상태라 “빈 장바구니”로 보일 수 있습니다.
- 장바구니 추가/삭제 플로우 확인 부탁드립니다.
  - 상세 페이지: 담기/이미 담김 케이스 confirm UX가 자연스러운지
  - 장바구니 페이지: “선택 삭제”가 담기 취소로 동작하는 흐름/상태 업데이트(items/selectedMap)가 자연스러운지
- 목업 분기 처리 위치/방식 괜찮은지 확인 부탁드립니다.

close #98
