### PR TITLE
feat: 구매 내역 페이지 UI 구성 및 주문 목록 조회 처리

### DIFF
--- a/src/app/(user)/mypage/MyPageSections.module.css
+++ b/src/app/(user)/mypage/MyPageSections.module.css
@@ -1,6 +1,6 @@
 .profile-section {
   display: grid;
-  gap: var(--space-5);
+  gap: var(--space-4);
 }
 
 .profile-section__header {
@@ -360,4 +360,326 @@
 .cart__cta:focus-visible {
   border-color: var(--color-brand);
   color: var(--color-brand);
+}
+
+/* 헤더 영역(타이틀 + 카운트) */
+.cart__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.cart__desc {
+  margin: 0;
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text-2, #6b7280);
+}
+
+.cart__desc strong {
+  color: var(--text-1, #111827);
+  font-weight: 700;
+}
+
+/* 빈 상태 */
+.cart__empty {
+  margin: 12px 0 0;
+  padding: 24px 16px;
+  border-radius: 16px;
+
+  text-align: center;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--text-2, #6b7280);
+  background: var(--surface-2, #f9fafb);
+  border: 1px solid var(--border-1, #e5e7eb);
+}
+
+/* 빈 상태 CTA */
+.cart__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  height: 44px;
+  border-radius: 12px;
+  padding: 0 14px;
+
+  font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
+
+  color: var(--on-primary, #ffffff);
+  background: var(--primary, #111827);
+}
+
+.cart__cta:hover {
+  filter: brightness(0.98);
+}
+
+/* =========================
+   Order (구매 내역) - cart와 분리
+========================= */
+
+.order {
+  display: grid;
+  gap: var(--space-4);
+}
+
+.order__header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.order__desc {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.order__desc strong {
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+.order__empty {
+  margin: 0;
+  color: var(--color-text-muted);
+  text-align: center;
+  padding: var(--space-5);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  background: var(--color-elevated);
+}
+
+.order__cta {
+  justify-self: center;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-weight: 600;
+
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.order__cta:hover,
+.order__cta:focus-visible {
+  border-color: var(--color-brand);
+  color: var(--color-brand);
+}
+
+.order-list {
+  display: grid;
+  gap: var(--space-3);
+}
+
+.order-card {
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-4);
+  background: var(--color-elevated);
+  display: grid;
+  gap: var(--space-3);
+}
+
+.order-card__top {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-2);
+}
+
+.order-card__meta {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-1);
+}
+
+.order-card__date {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.order-card__order {
+  margin: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  display: flex;
+  gap: var(--space-1);
+  flex-wrap: wrap;
+}
+
+.order-card__order span {
+  color: var(--color-text);
+  font-weight: 600;
+  word-break: break-all;
+}
+
+.order-card__right {
+  display: flex;
+  align-items: center;
+  justify-content: space-between; /* 뱃지 왼쪽, 금액 오른쪽 */
+  gap: var(--space-2);
+}
+
+.order-card__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  height: 24px;
+  padding: 0 var(--space-2);
+  border-radius: 999px;
+
+  font-size: var(--text-xs);
+  font-weight: 700;
+  line-height: 1;
+
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+}
+
+/* 상태별 */
+.order-card__badge[data-status='COMPLETED'] {
+  border-color: rgba(16, 185, 129, 0.35);
+  background: rgba(16, 185, 129, 0.08);
+  color: rgb(4, 120, 87);
+}
+
+.order-card__badge[data-status='PARTIAL_CANCELED'] {
+  border-color: rgba(245, 158, 11, 0.35);
+  background: rgba(245, 158, 11, 0.1);
+  color: rgb(180, 83, 9);
+}
+
+.order-card__badge[data-status='CANCELED'] {
+  border-color: rgba(239, 68, 68, 0.35);
+  background: rgba(239, 68, 68, 0.08);
+  color: rgb(185, 28, 28);
+}
+
+.order-card__badge[data-status='REFUNDED'] {
+  border-color: var(--color-border);
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--color-text-muted);
+}
+
+.order-card__price {
+  margin: 0;
+  font-size: var(--text-lg);
+  font-weight: 800;
+  color: var(--color-text);
+}
+
+.order-card__items {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+}
+
+.order-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: var(--space-3);
+  padding-top: var(--space-2);
+  border-top: 1px solid var(--color-border);
+}
+
+.order-card__items li:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.order-item__main {
+  min-width: 0;
+  display: grid;
+  gap: 4px;
+}
+
+.order-item__title {
+  margin: 0;
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-text);
+
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.order-item__price {
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+  font-weight: 700;
+  color: var(--color-text);
+}
+
+.order-card__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.order-card__link {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: var(--space-2) var(--space-4);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  text-decoration: none;
+  font-size: var(--text-sm);
+  font-weight: 600;
+
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.order-card__link:hover,
+.order-card__link:focus-visible {
+  border-color: var(--color-brand);
+  color: var(--color-brand);
+}
+
+.order-card__link--primary {
+  border-color: var(--color-brand);
+  color: var(--color-brand);
+}
+
+@media (min-width: 480px) {
+  .order-card__top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--space-3);
+  }
+
+  .order-card__right {
+    display: grid;
+    justify-items: end;
+    gap: var(--space-2);
+  }
 }

--- a/src/app/(user)/mypage/MyPageSections.module.css
+++ b/src/app/(user)/mypage/MyPageSections.module.css
@@ -488,22 +488,25 @@
 .order-card {
   border: 1px solid var(--color-border);
   border-radius: var(--radius-md);
-  padding: var(--space-4);
+  padding: var(--space-3);
   background: var(--color-elevated);
   display: grid;
-  gap: var(--space-3);
+  gap: var(--space-2);
+  position: relative;
 }
 
 .order-card__top {
-  display: grid;
-  grid-template-columns: 1fr;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   gap: var(--space-2);
+  padding-right: calc(var(--space-6) + var(--space-2));
 }
 
 .order-card__meta {
   min-width: 0;
   display: grid;
-  gap: var(--space-1);
+  gap: 2px;
 }
 
 .order-card__date {
@@ -530,8 +533,11 @@
 .order-card__right {
   display: flex;
   align-items: center;
-  justify-content: space-between; /* 뱃지 왼쪽, 금액 오른쪽 */
+  justify-content: flex-end;
   gap: var(--space-2);
+  position: absolute;
+  top: var(--space-3);
+  right: var(--space-3);
 }
 
 .order-card__badge {
@@ -539,11 +545,11 @@
   align-items: center;
   justify-content: center;
 
-  height: 24px;
-  padding: 0 var(--space-2);
+  height: 28px;
+  padding: 0 var(--space-3);
   border-radius: 999px;
 
-  font-size: var(--text-xs);
+  font-size: var(--text-sm);
   font-weight: 700;
   line-height: 1;
 
@@ -585,11 +591,9 @@
 }
 
 .order-card__items {
-  list-style: none;
   margin: 0;
   padding: 0;
-  display: grid;
-  gap: var(--space-2);
+  margin-top: 2px;
 }
 
 .order-item {
@@ -631,10 +635,127 @@
   color: var(--color-text);
 }
 
+.order-item__details {
+  width: 100%;
+  display: grid;
+  gap: 0;
+  padding-top: var(--space-2);
+  border-top: none;
+}
+
+.order-item__summary-toggle {
+  cursor: pointer;
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding-block: var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.order-item__summary-toggle::-webkit-details-marker {
+  display: none;
+}
+
+.order-item__summary-toggle::marker {
+  content: '';
+}
+
+.order-item__single {
+  padding-block: var(--space-1);
+}
+
+.order-item__summary-title {
+  min-width: 0;
+  flex: 1;
+  color: var(--color-text);
+  font-weight: 600;
+  font-size: var(--text-sm);
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.order-item__summary-count {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+  font-weight: 600;
+}
+
+.order-item__summary-toggle::after {
+  content: '▾';
+  flex-shrink: 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  opacity: 0.7;
+  transition: transform 0.2s ease;
+}
+
+.order-item__details[open] .order-item__summary-toggle::after {
+  transform: rotate(180deg);
+}
+
+.order-item__more {
+  list-style: none;
+  margin: var(--space-1) 0 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-2);
+  padding-left: var(--space-3);
+}
+
+.order-item__more li:first-child {
+  padding-top: 0;
+  border-top: none;
+}
+
+.order-item__more .order-item {
+  padding-top: 0;
+  border-top: none;
+}
+
+.order-item__more .order-item__title {
+  font-size: var(--text-sm);
+  font-weight: 500;
+  color: var(--color-text-muted);
+}
+
+.order-item__more .order-item__title::before {
+  content: '+';
+  margin-right: var(--space-1);
+  color: var(--color-text-muted);
+}
+
+.order-item__more .order-item__price {
+  font-size: var(--text-xs);
+  font-weight: 600;
+  color: var(--color-text-muted);
+}
+
+.order-card__total {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+  padding-top: var(--space-1);
+  border-top: 1px solid var(--color-border);
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}
+
+.order-card__total strong {
+  font-size: var(--text-lg);
+  font-weight: 800;
+  color: var(--color-text);
+}
+
 .order-card__actions {
   display: flex;
   justify-content: flex-end;
-  gap: var(--space-2);
+  gap: var(--space-1);
   flex-wrap: wrap;
 }
 
@@ -669,17 +790,46 @@
   color: var(--color-brand);
 }
 
+@media (max-width: 479px) {
+  .order-card__actions {
+    gap: var(--space-1);
+  }
+
+  .order-card__link {
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-xs);
+  }
+
+  .order-card__badge {
+    height: 24px;
+    padding: 0 var(--space-2);
+    font-size: var(--text-xs);
+  }
+}
+
 @media (min-width: 480px) {
   .order-card__top {
-    display: flex;
-    justify-content: space-between;
     align-items: flex-start;
     gap: var(--space-3);
+    padding-right: 0;
   }
 
   .order-card__right {
     display: grid;
     justify-items: end;
     gap: var(--space-2);
+    position: static;
+  }
+}
+
+@media (min-width: 1024px) {
+  .order-card__actions {
+    align-items: flex-end;
+  }
+
+  .order-card__link {
+    min-width: 120px;
+    padding: var(--space-1) var(--space-3);
+    font-size: var(--text-xs);
   }
 }

--- a/src/app/(user)/mypage/cart/page.tsx
+++ b/src/app/(user)/mypage/cart/page.tsx
@@ -35,62 +35,80 @@ export default async function PurchaseHistoryPage() {
         </>
       ) : (
         <div className={styles['order-list']} aria-label="구매 내역 목록">
-          {orders.map((order) => (
-            <article key={order.orderId} className={styles['order-card']}>
-              <div className={styles['order-card__top']}>
-                <div className={styles['order-card__meta']}>
-                  <p className={styles['order-card__date']}>{formatDate(order.paidAt)}</p>
-                  <p className={styles['order-card__order']}>
-                    주문번호 <span>{order.orderId}</span>
-                  </p>
+          {orders.map((order) => {
+            const firstCourse = order.courses[0];
+            const remainingCount = Math.max(order.courses.length - 1, 0);
+
+            return (
+              <article key={order.orderId} className={styles['order-card']}>
+                <div className={styles['order-card__top']}>
+                  <div className={styles['order-card__meta']}>
+                    <p className={styles['order-card__date']}>{formatDate(order.paidAt)}</p>
+                    <p className={styles['order-card__order']}>
+                      주문번호 <span>{order.orderId}</span>
+                    </p>
+                  </div>
+
+                  <div className={styles['order-card__right']}>
+                    <span className={styles['order-card__badge']} data-status={order.status}>
+                      {getOrderStatusLabel(order.status)}
+                    </span>
+                  </div>
                 </div>
 
-                <div className={styles['order-card__right']}>
-                  <span className={styles['order-card__badge']} data-status={order.status}>
-                    {getOrderStatusLabel(order.status)}
-                  </span>
-                  <p className={styles['order-card__price']}>
-                    {order.totalAmount.toLocaleString()}원
-                  </p>
+                <div className={styles['order-card__items']} aria-label="구매 강좌 목록">
+                  {firstCourse ? (
+                    remainingCount > 0 ? (
+                      <details className={styles['order-item__details']}>
+                        <summary className={styles['order-item__summary-toggle']}>
+                          <span className={styles['order-item__summary-title']}>
+                            {firstCourse.title}
+                          </span>
+                          <span className={styles['order-item__summary-count']}>
+                            외 {remainingCount}건
+                          </span>
+                        </summary>
+                        <ul className={styles['order-item__more']}>
+                          {order.courses.map((course) => (
+                            <li
+                              key={`${order.orderId}-${course.courseId}`}
+                              className={styles['order-item']}
+                            >
+                              <div className={styles['order-item__main']}>
+                                <p className={styles['order-item__title']}>{course.title}</p>
+                              </div>
+
+                              <div className={styles['order-item__price']}>
+                                {course.price.toLocaleString()}원
+                              </div>
+                            </li>
+                          ))}
+                        </ul>
+                      </details>
+                    ) : (
+                      <div className={styles['order-item__single']}>
+                        <span className={styles['order-item__summary-title']}>
+                          {firstCourse.title}
+                        </span>
+                      </div>
+                    )
+                  ) : null}
                 </div>
-              </div>
 
-              <ul className={styles['order-card__items']} aria-label="구매 강좌 목록">
-                {order.courses.map((course) => (
-                  <li key={`${order.orderId}-${course.courseId}`} className={styles['order-item']}>
-                    <div className={styles['order-item__main']}>
-                      <p className={styles['order-item__title']}>{course.title}</p>
-                    </div>
-
-                    <div className={styles['order-item__price']}>
-                      {course.price.toLocaleString()}원
-                    </div>
-                  </li>
-                ))}
-              </ul>
-
-              <div className={styles['order-card__actions']}>
-                <Link className={styles['order-card__link']} href={`/orders/${order.orderId}`}>
-                  상세 보기
-                </Link>
-
-                {order.courses[0]?.courseId ? (
-                  <Link
-                    className={styles['order-card__link']}
-                    href={`/courses/${order.courses[0].courseId}`}
-                  >
-                    강좌로 이동
-                  </Link>
-                ) : null}
-              </div>
-            </article>
-          ))}
+                <div className={styles['order-card__total']}>
+                  <span>합계</span>
+                  <strong>{order.totalAmount.toLocaleString()}원</strong>
+                </div>
+              </article>
+            );
+          })}
         </div>
       )}
     </section>
   );
 }
 
+// TODO: OrderStatus 변경 시 동기화 필요
 const getOrderStatusLabel = (status: OrderStatus) => {
   switch (status) {
     case 'COMPLETED':

--- a/src/app/(user)/mypage/cart/page.tsx
+++ b/src/app/(user)/mypage/cart/page.tsx
@@ -1,16 +1,107 @@
 import Link from 'next/link';
 import styles from '@/app/(user)/mypage/MyPageSections.module.css';
+import type { OrderStatus } from '@/domains/user/types/order';
+import { formatDate } from '@/shared/util/formatDate';
+import { getOrders } from '@/domains/user/services/orderService';
+import { MOCK_GET_ORDERS } from '@/mocks/order.mock';
 
-export default function PurchaseHistoryPage() {
+export default async function PurchaseHistoryPage() {
+  // TODO: API 정상화 후 제거 또는 MSW로 전환
+  const { orders, totalCount } =
+    process.env.NODE_ENV === 'development' ? MOCK_GET_ORDERS : await getOrders();
+
+  const isEmpty = orders.length === 0;
+
   return (
-    <section className={styles['cart']} aria-labelledby="mypage-purchase-title">
-      <h1 id="mypage-purchase-title" className={styles['profile-section__title']}>
-        구매 내역
-      </h1>
-      <p className={styles['cart__empty']}>구매 내역이 없습니다.</p>
-      <Link className={styles['cart__cta']} href="/">
-        강좌 보러 가기
-      </Link>
+    <section className={styles.order} aria-labelledby="mypage-purchase-title">
+      <header className={styles.order__header}>
+        <h1 id="mypage-purchase-title" className={styles['profile-section__title']}>
+          구매 내역
+        </h1>
+
+        {!isEmpty && (
+          <p className={styles['order__desc']}>
+            총 <strong>{totalCount}</strong>건
+          </p>
+        )}
+      </header>
+
+      {isEmpty ? (
+        <>
+          <p className={styles['order__empty']}>구매 내역이 없습니다.</p>
+          <Link className={styles['order__cta']} href="/">
+            강좌 보러 가기
+          </Link>
+        </>
+      ) : (
+        <div className={styles['order-list']} aria-label="구매 내역 목록">
+          {orders.map((order) => (
+            <article key={order.orderId} className={styles['order-card']}>
+              <div className={styles['order-card__top']}>
+                <div className={styles['order-card__meta']}>
+                  <p className={styles['order-card__date']}>{formatDate(order.paidAt)}</p>
+                  <p className={styles['order-card__order']}>
+                    주문번호 <span>{order.orderId}</span>
+                  </p>
+                </div>
+
+                <div className={styles['order-card__right']}>
+                  <span className={styles['order-card__badge']} data-status={order.status}>
+                    {getOrderStatusLabel(order.status)}
+                  </span>
+                  <p className={styles['order-card__price']}>
+                    {order.totalAmount.toLocaleString()}원
+                  </p>
+                </div>
+              </div>
+
+              <ul className={styles['order-card__items']} aria-label="구매 강좌 목록">
+                {order.courses.map((course) => (
+                  <li key={`${order.orderId}-${course.courseId}`} className={styles['order-item']}>
+                    <div className={styles['order-item__main']}>
+                      <p className={styles['order-item__title']}>{course.title}</p>
+                    </div>
+
+                    <div className={styles['order-item__price']}>
+                      {course.price.toLocaleString()}원
+                    </div>
+                  </li>
+                ))}
+              </ul>
+
+              <div className={styles['order-card__actions']}>
+                <Link className={styles['order-card__link']} href={`/orders/${order.orderId}`}>
+                  상세 보기
+                </Link>
+
+                {order.courses[0]?.courseId ? (
+                  <Link
+                    className={styles['order-card__link']}
+                    href={`/courses/${order.courses[0].courseId}`}
+                  >
+                    강좌로 이동
+                  </Link>
+                ) : null}
+              </div>
+            </article>
+          ))}
+        </div>
+      )}
     </section>
   );
 }
+
+const getOrderStatusLabel = (status: OrderStatus) => {
+  switch (status) {
+    case 'COMPLETED':
+      return '결제 완료';
+    case 'PARTIAL_CANCELED':
+      return '부분 취소';
+    case 'CANCELED':
+      return '결제 취소';
+    case 'REFUNDED':
+      return '환불 완료';
+    default:
+      return status;
+  }
+};

--- a/src/domains/auth/hooks/useAuthState.ts
+++ b/src/domains/auth/hooks/useAuthState.ts
@@ -1,8 +1,6 @@
 'use client';
 
 import { useAuthStore, useUserStore } from '@/domains/auth/store/useAuthStore';
-// TODO : 임시 목업 데이터
-import { MOCK_USER } from '@/mocks/user.mock';
 
 export const useAuthState = () => {
   const user = useUserStore((s) => s.user);
@@ -13,8 +11,7 @@ export const useAuthState = () => {
   const isLoading = useAuthStore((s) => s.isUserProfileLoading);
 
   return {
-    // TODO : 임시 목업 데이터
-    user: MOCK_USER,
+    user,
     setUser,
     clearUser,
     loading: !isLoaded || isLoading,

--- a/src/domains/course/services/courseCreateService.ts
+++ b/src/domains/course/services/courseCreateService.ts
@@ -56,24 +56,6 @@ export const createCourse = async (
 
 // 카테고리 조회 API
 export const getCategories = async (): Promise<Category[]> => {
-  // TODO: 임시 목업 데이터, 카테고리 조회 API 완성되면 제거
-  if (process.env.NODE_ENV === 'development') {
-    return [
-      {
-        categoryId: 1,
-        name: '프로그래밍',
-        children: [
-          { categoryId: 2, name: '프론트엔드' },
-          { categoryId: 3, name: '백엔드' },
-        ],
-      },
-      {
-        categoryId: 4,
-        name: '디자인',
-        children: [{ categoryId: 5, name: 'UI/UX' }],
-      },
-    ];
-  }
   try {
     const categories = await getApi<Category[]>('/api/categories');
     return categories;

--- a/src/domains/user/services/orderService.ts
+++ b/src/domains/user/services/orderService.ts
@@ -1,0 +1,14 @@
+import { getApi } from '@/shared/lib/api/fetchApi';
+import { GetOrdersParams, GetOrdersResponse } from '../types/order';
+
+/**
+ * 주문 목록 조회
+ */
+export const getOrders = async (params?: GetOrdersParams): Promise<GetOrdersResponse> => {
+  const query = new URLSearchParams({
+    page: String(params?.page ?? 0),
+    size: String(params?.size ?? 10),
+  });
+
+  return await getApi<GetOrdersResponse>(`/api/orders?${query.toString()}`);
+};

--- a/src/domains/user/types/order.ts
+++ b/src/domains/user/types/order.ts
@@ -1,0 +1,25 @@
+export type OrderStatus = 'COMPLETED' | 'PARTIAL_CANCELED' | 'CANCELED' | 'REFUNDED'; // TODO: API 명세 확인 필요
+
+export type Order = {
+  orderId: string;
+  paidAt: string;
+  status: OrderStatus;
+  totalAmount: number;
+  // TODO: API 명세 확인 필요
+  courses: {
+    courseId: string;
+    title: string;
+    price: number;
+  }[];
+};
+
+export type GetOrdersParams = {
+  page?: number;
+  size?: number;
+};
+export type GetOrdersResponse = {
+  page: number;
+  size: number;
+  totalCount: number;
+  orders: Order[];
+};

--- a/src/mocks/order.mock.ts
+++ b/src/mocks/order.mock.ts
@@ -3,7 +3,7 @@ import { GetOrdersResponse } from '@/domains/user/types/order';
 export const MOCK_GET_ORDERS: GetOrdersResponse = {
   page: 1,
   size: 10,
-  totalCount: 2,
+  totalCount: 3,
   orders: [
     {
       orderId: 'ORD-20260111-0001',
@@ -13,9 +13,20 @@ export const MOCK_GET_ORDERS: GetOrdersResponse = {
       courses: [{ courseId: 'c_101', title: 'Next.js App Router 실전', price: 39000 }],
     },
     {
+      orderId: 'ORD-20260110-0002',
+      paidAt: '2026-01-10T14:05:00.000Z',
+      status: 'COMPLETED',
+      totalAmount: 78000, // 39000 + 29000 + 10000
+      courses: [
+        { courseId: 'c_101', title: 'Next.js App Router 실전', price: 39000 },
+        { courseId: 'c_204', title: 'React Query로 서버 상태 관리', price: 29000 },
+        { courseId: 'c_150', title: 'TypeScript 타입 설계 패턴', price: 10000 },
+      ],
+    },
+    {
       orderId: 'ORD-20260105-0003',
       paidAt: '2026-01-05T08:10:00.000Z',
-      status: 'REFUNDED',
+      status: 'CANCELED',
       totalAmount: 25000,
       courses: [{ courseId: 'c_085', title: 'AWS 기초부터 배포까지', price: 25000 }],
     },

--- a/src/mocks/order.mock.ts
+++ b/src/mocks/order.mock.ts
@@ -1,0 +1,23 @@
+import { GetOrdersResponse } from '@/domains/user/types/order';
+
+export const MOCK_GET_ORDERS: GetOrdersResponse = {
+  page: 1,
+  size: 10,
+  totalCount: 2,
+  orders: [
+    {
+      orderId: 'ORD-20260111-0001',
+      paidAt: '2026-01-11T10:20:00.000Z',
+      status: 'COMPLETED',
+      totalAmount: 39000,
+      courses: [{ courseId: 'c_101', title: 'Next.js App Router 실전', price: 39000 }],
+    },
+    {
+      orderId: 'ORD-20260105-0003',
+      paidAt: '2026-01-05T08:10:00.000Z',
+      status: 'REFUNDED',
+      totalAmount: 25000,
+      courses: [{ courseId: 'c_085', title: 'AWS 기초부터 배포까지', price: 25000 }],
+    },
+  ],
+};

--- a/src/shared/util/formatDate.ts
+++ b/src/shared/util/formatDate.ts
@@ -1,0 +1,8 @@
+export const formatDate = (iso: string) => {
+  const d = new Date(iso);
+  return d.toLocaleDateString('ko-KR', {
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+};


### PR DESCRIPTION
## 변경 사항

* 구매 내역 UI 추가: 리스트 카드/아이템 구성 + 금액/일자/상태 뱃지 표시, 상세/강좌 이동 링크 연결
* 주문 목록 조회 임시 처리: 목업 렌더링 + 추후 API 연동 포인트(TODO) 추가
  * 목업 데이터(`MOCK_GET_ORDERS`)로 렌더링
* 마이페이지 스타일 업데이트: `MyPageSections`에 구매 내역(`order-*`) 전용 스타일 추가 및 `profile-section` gap 조정
* 기타
  * 주문(Order) 타입 추가
  * 개발용 목업 분기 정리: 카테고리 조회 목업 분기 제거, `useAuthState` 유저 목업 데이터 정리
  * `formatDate` 유틸 추가

## 리뷰 필요

* 주문 목록 조회 시 목업 기반 렌더링 흐름(개발 환경 분기)이 의도대로 동작하는지 확인 부탁드립니다.

close #109
