### PR TITLE
feat: 강의 이어보기 및 학습 진도 관리 로직 구현

### DIFF
--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -19,7 +19,7 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
   const [learnData, setLearnData] = useState<CourseLearn | null>(null);
   const [currentLecture, setCurrentLecture] = useState<UILecture | null>(null);
   const [openSections, setOpenSections] = useState<string[]>([]);
-  const { resumeInfo, lectureProgressMap } = useProgress(enrollmentId);
+  const { progressInfo, lectureProgressMap } = useProgress(enrollmentId);
 
   useEffect(() => {
     if (!courseId || !enrollmentId) return;
@@ -100,10 +100,10 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
       return;
     }
 
-    if (resumeInfo?.lectureId) {
+    if (progressInfo?.lectureId) {
       const found = courseData.sections
         .flatMap((s) => s.lectures)
-        .find((l) => l.id === resumeInfo.lectureId);
+        .find((l) => l.id === progressInfo.lectureId);
 
       if (found) {
         setCurrentLecture(found);
@@ -113,7 +113,7 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
 
     const first = courseData.sections[0]?.lectures[0] ?? null;
     setCurrentLecture(first);
-  }, [courseData, options?.start, resumeInfo?.lectureId]);
+  }, [courseData, options?.start, progressInfo?.lectureId]);
 
   const handleLectureClick = (lecture: UILecture) => {
     setCurrentLecture(lecture);
@@ -136,16 +136,16 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
 
   function resolveStartLecture(
     lectures: UILecture[],
-    resumeInfo: ProgressInfo | null,
+    progressInfo: ProgressInfo | null,
     lectureProgressMap: Map<string, LectureProgressMapValue>,
   ): UILecture {
-    if (!resumeInfo) return lectures[0];
+    if (!progressInfo) return lectures[0];
 
-    const idx = lectures.findIndex((l) => l.id === resumeInfo.lectureId);
+    const idx = lectures.findIndex((l) => l.id === progressInfo.lectureId);
 
     if (idx === -1) return lectures[0];
 
-    const progress = lectureProgressMap.get(resumeInfo.lectureId);
+    const progress = lectureProgressMap.get(progressInfo.lectureId);
 
     if (progress?.completed) {
       return lectures[idx + 1] ?? lectures[idx];

--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -1,17 +1,13 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useParams } from 'next/navigation';
-
-import type { CourseLearn, UILecture } from '@/domains/course/types/learn';
+import type { CourseLearn, UILecture, UICourse } from '@/domains/course/types/learn';
 import { getCourse } from '@/domains/course/services/learnService';
 import { mapCourse } from '@/domains/course/utils/mapCourse';
-
-import {
-  MOCK_LEARN_COURSE_MAP,
-  MOCK_LEARN_ENROLLMENT,
-  MOCK_LEARN_PROGRESS,
-} from '@/mocks/learn.mock';
+import { useCourseLearnProgress } from '@/domains/course/hooks/useCourseLearnProgress';
+import { MOCK_LEARN_COURSE_MAP, MOCK_LEARN_ENROLLMENT } from '@/mocks/learn.mock';
+import { LectureProgressMapValue, ResumeInfo } from '../types/progress';
 
 type UseCourseLearnOptions = {
   start?: 'first';
@@ -20,13 +16,10 @@ type UseCourseLearnOptions = {
 export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOptions) {
   const params = useParams<{ id: string }>();
   const courseId = params?.id;
-
   const [learnData, setLearnData] = useState<CourseLearn | null>(null);
   const [currentLecture, setCurrentLecture] = useState<UILecture | null>(null);
   const [openSections, setOpenSections] = useState<string[]>([]);
-
-  // TODO: UI 검증용 완료 상태 (서버 progress 대신 사용)
-  const [uiCompletedLectureIds, setUiCompletedLectureIds] = useState<Set<string>>(() => new Set());
+  const { resumeInfo, lectureProgressMap } = useCourseLearnProgress(enrollmentId);
 
   useEffect(() => {
     if (!courseId || !enrollmentId) return;
@@ -38,7 +31,6 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
     setLearnData({
       course,
       enrollment: MOCK_LEARN_ENROLLMENT,
-      progress: MOCK_LEARN_PROGRESS,
     });
 
     /**
@@ -57,10 +49,8 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
   }, [courseId, enrollmentId]);
 
   // TODO: UI 완료 상태 기준으로 courseData 생성
-  const courseData = useMemo(() => {
+  const courseData = useMemo<UICourse | null>(() => {
     if (!learnData) return null;
-
-    return mapCourse(learnData.course, uiCompletedLectureIds);
 
     /**
      * TODO: 서버 기준 원본 코드
@@ -69,34 +59,10 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
      *   learnData.progress?.completedLectureIds ?? [],
      * );
      *
-     * return mapCourse(learnData.course, completedIds);
+     * return mapCourse(learnData.course, lectureProgressMap);
      */
-  }, [learnData, uiCompletedLectureIds]);
-
-  useEffect(() => {
-    if (!courseData) return;
-    if (currentLecture) return;
-
-    if (options?.start === 'first') {
-      setCurrentLecture(courseData.sections[0]?.lectures[0] ?? null);
-      return;
-    }
-
-    setCurrentLecture(courseData.sections[0]?.lectures[0] ?? null);
-
-    /**
-     * TODO: 서버 기준 원본 (이어보기)
-     *
-     * const lastId = learnData?.progress?.lastVideoId;
-     * const found = lastId
-     *   ? courseData.sections
-     *       .flatMap((s) => s.lectures)
-     *       .find((l) => l.id === lastId)
-     *   : null;
-     *
-     * setCurrentLecture(found ?? courseData.sections[0]?.lectures[0] ?? null);
-     */
-  }, [courseData, currentLecture, options?.start]);
+    return mapCourse(learnData.course, lectureProgressMap);
+  }, [learnData, lectureProgressMap]);
 
   const currentSectionId = useMemo(() => {
     if (!courseData || !currentLecture) return null;
@@ -108,6 +74,12 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
   }, [courseData, currentLecture]);
 
   useEffect(() => {
+    if (!courseData) return;
+
+    setOpenSections(courseData.sections.map((s) => s.id));
+  }, [courseData]);
+
+  useEffect(() => {
     if (!currentSectionId) return;
 
     setOpenSections((prev) =>
@@ -115,81 +87,80 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
     );
   }, [currentSectionId]);
 
+  const initializedRef = useRef(false);
+  useEffect(() => {
+    if (!courseData) return;
+    if (initializedRef.current) return;
+
+    initializedRef.current = true;
+
+    if (options?.start === 'first') {
+      const first = courseData.sections[0]?.lectures[0] ?? null;
+      setCurrentLecture(first);
+      return;
+    }
+
+    if (resumeInfo?.lectureId) {
+      const found = courseData.sections
+        .flatMap((s) => s.lectures)
+        .find((l) => l.id === resumeInfo.lectureId);
+
+      if (found) {
+        setCurrentLecture(found);
+        return;
+      }
+    }
+
+    const first = courseData.sections[0]?.lectures[0] ?? null;
+    setCurrentLecture(first);
+  }, [courseData, options?.start, resumeInfo?.lectureId]);
+
   const handleLectureClick = (lecture: UILecture) => {
     setCurrentLecture(lecture);
   };
 
-  // TODO: 영상 종료 → UI 완료 처리
-  const handleVideoEnded = () => {
-    if (!currentLecture) return;
+  const moveToNextLecture = () => {
+    if (!courseData || !currentLecture) return;
 
-    setUiCompletedLectureIds((prev) => {
-      const next = new Set(prev);
-      next.add(currentLecture.id);
-      return next;
-    });
+    const flatLectures = courseData.sections.flatMap((section) => section.lectures);
 
-    /**
-     * TODO: 서버 기준 원본
-     *
-     * await updateLearnProgress({
-     *   resourceId: currentLecture.id,
-     *   watchedDuration: currentLecture.duration,
-     * });
-     */
+    const currentIndex = flatLectures.findIndex((l) => l.id === currentLecture.id);
+
+    if (currentIndex === -1) return;
+
+    const nextLecture = flatLectures[currentIndex + 1];
+    if (!nextLecture) return;
+
+    setCurrentLecture(nextLecture);
   };
 
-  // TODO: 영상 시청 중 (UI 검증 단계에서는 아무 것도 안 함)
-  const handleVideoTimeUpdate = () => {
-    /**
-     * TODO: 서버 기준 원본
-     *
-     * await updateLearnProgress({
-     *   resourceId: currentLecture.id,
-     *   watchedDuration,
-     * });
-     */
-  };
+  function resolveStartLecture(
+    lectures: UILecture[],
+    resumeInfo: ResumeInfo | null,
+    lectureProgressMap: Map<string, LectureProgressMapValue>,
+  ): UILecture {
+    if (!resumeInfo) return lectures[0];
 
-  // TODO: PDF 완료 처리 (다운로드 시)
-  const markPdfCompleted = (lecture: UILecture) => {
-    setUiCompletedLectureIds((prev) => {
-      const next = new Set(prev);
-      next.add(lecture.id);
-      return next;
-    });
+    const idx = lectures.findIndex((l) => l.id === resumeInfo.lectureId);
 
-    /**
-     * TODO: 서버 기준 원본
-     *
-     * await updateLearnProgress({
-     *   resourceId: lecture.id,
-     *   watchedDuration: 0,
-     * });
-     */
-  };
+    if (idx === -1) return lectures[0];
 
-  const totalLectures = useMemo(() => {
-    if (!courseData) return 0;
-    return courseData.sections.reduce((acc, s) => acc + s.lectures.length, 0);
-  }, [courseData]);
+    const progress = lectureProgressMap.get(resumeInfo.lectureId);
 
-  const completedLectures = uiCompletedLectureIds.size;
+    if (progress?.completed) {
+      return lectures[idx + 1] ?? lectures[idx];
+    }
+
+    return lectures[idx];
+  }
 
   return {
     courseData,
     currentLecture,
     openSections,
     handleLectureClick,
-    handleVideoEnded,
-    handleVideoTimeUpdate,
     toggleSection: (id: string) =>
       setOpenSections((prev) => (prev.includes(id) ? prev.filter((v) => v !== id) : [...prev, id])),
-    markPdfCompleted,
-
-    learnData,
-    totalLectures,
-    completedLectures,
-    lastWatchedDuration: 0,
+    moveToNextLecture,
   };
 }

--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -5,7 +5,7 @@ import { useParams } from 'next/navigation';
 import type { CourseLearn, UILecture, UICourse } from '@/domains/course/types/learn';
 import { getCourse } from '@/domains/course/services/learnService';
 import { mapCourse } from '@/domains/course/utils/mapCourse';
-import { useCourseLearnProgress } from '@/domains/course/hooks/useCourseLearnProgress';
+import { useProgress } from '@/domains/course/hooks/useProgress';
 import { MOCK_LEARN_COURSE_MAP, MOCK_LEARN_ENROLLMENT } from '@/mocks/learn.mock';
 import { LectureProgressMapValue, ResumeInfo } from '../types/progress';
 
@@ -19,7 +19,7 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
   const [learnData, setLearnData] = useState<CourseLearn | null>(null);
   const [currentLecture, setCurrentLecture] = useState<UILecture | null>(null);
   const [openSections, setOpenSections] = useState<string[]>([]);
-  const { resumeInfo, lectureProgressMap } = useCourseLearnProgress(enrollmentId);
+  const { resumeInfo, lectureProgressMap } = useProgress(enrollmentId);
 
   useEffect(() => {
     if (!courseId || !enrollmentId) return;

--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -134,7 +134,7 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
     setCurrentLecture(nextLecture);
   };
 
-  function resolveStartLecture(
+  function selectLectureToWatch(
     lectures: UILecture[],
     progressInfo: ProgressInfo | null,
     lectureProgressMap: Map<string, LectureProgressMapValue>,

--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -7,7 +7,7 @@ import { getCourse } from '@/domains/course/services/learnService';
 import { mapCourse } from '@/domains/course/utils/mapCourse';
 import { useProgress } from '@/domains/course/hooks/useProgress';
 import { MOCK_LEARN_COURSE_MAP, MOCK_LEARN_ENROLLMENT } from '@/mocks/learn.mock';
-import { LectureProgressMapValue, ResumeInfo } from '../types/progress';
+import { LectureProgressMapValue, ProgressInfo } from '../types/progress';
 
 type UseCourseLearnOptions = {
   start?: 'first';
@@ -136,7 +136,7 @@ export function useCourseLearn(enrollmentId: string, options?: UseCourseLearnOpt
 
   function resolveStartLecture(
     lectures: UILecture[],
-    resumeInfo: ResumeInfo | null,
+    resumeInfo: ProgressInfo | null,
     lectureProgressMap: Map<string, LectureProgressMapValue>,
   ): UILecture {
     if (!resumeInfo) return lectures[0];

--- a/src/domains/course/hooks/useCourseLearnProgress.ts
+++ b/src/domains/course/hooks/useCourseLearnProgress.ts
@@ -1,0 +1,200 @@
+'use client';
+
+import { useEffect, useMemo, useRef, useState } from 'react';
+
+import type {
+  CourseLearnProgress,
+  LearnProgressResponse,
+  LectureProgressMapValue,
+  ResumeInfo,
+  PendingProgress,
+} from '@/domains/course/types/progress';
+
+// TODO: 실제 API (복구용)
+// import { getLearnProgress, updateLearnProgress } from '@/domains/course/services/learnService';
+
+import { MOCK_LEARN_PROGRESS } from '@/mocks/learn.mock';
+
+export function useCourseLearnProgress(enrollmentId: string) {
+  const [progressData, setProgressData] = useState<LearnProgressResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!enrollmentId) return;
+
+    /**
+     * TODO: 서버 연동 원본 코드 (복구용)
+     * async function fetchProgress() {
+     *   try {
+     *     setIsLoading(true);
+     *     const response = await getLearnProgress(enrollmentId);
+     *     setProgressData(response);
+     *   } catch (e) {
+     *     setError(e as Error);
+     *   } finally {
+     *     setIsLoading(false);
+     *   }
+     * }
+     *
+     * fetchProgress();
+     */
+
+    // TODO: UI 검증용 mock 데이터
+    setIsLoading(true);
+    setProgressData(MOCK_LEARN_PROGRESS);
+    setIsLoading(false);
+  }, [enrollmentId]);
+
+  const lectureProgressMap = useMemo<Map<string, LectureProgressMapValue>>(() => {
+    if (!progressData) return new Map();
+
+    return new Map(
+      progressData.lectureProgresses.map((p) => [
+        p.resourceId,
+        {
+          progressRate: p.currentProgressRate,
+          watchedDuration: p.watchedDuration,
+          totalDurationSeconds: p.totalDurationSeconds,
+          completed: p.isCompleted,
+        },
+      ]),
+    );
+  }, [progressData]);
+
+  const resumeInfo = useMemo<ResumeInfo | null>(() => {
+    if (!progressData?.lastVideoId) return null;
+
+    return {
+      lectureId: progressData.lastVideoId,
+      resumeAt: progressData.lastWatchedDuration ?? 0,
+    };
+  }, [progressData]);
+
+  const progress = useMemo<CourseLearnProgress | null>(() => {
+    if (!progressData) return null;
+
+    return {
+      enrollmentId: progressData.enrollmentId,
+      overallProgressRate: progressData.progressRate,
+      resumeInfo,
+      lectureProgressMap,
+    };
+  }, [progressData, resumeInfo, lectureProgressMap]);
+
+  const lastSavedAtRef = useRef<number>(0);
+  const lastSavedDurationRef = useRef<number>(0);
+
+  const pendingRef = useRef<PendingProgress | null>(null);
+
+  const THROTTLE_INTERVAL = 10;
+  const MIN_SAVE_DELTA = 3;
+  const RETRY_DELAYS = [2000, 5000, 15000];
+
+  const retryPending = () => {
+    const pending = pendingRef.current;
+    if (!pending) return;
+
+    const delay = RETRY_DELAYS[pending.retryCount];
+    if (!delay) return; // 재시도 포기
+
+    setTimeout(async () => {
+      try {
+        /**
+         * await updateLearnProgress({
+         *   resourceId: pending.resourceId,
+         *   watchedDuration: pending.watchedDuration,
+         * });
+         */
+
+        setProgressData((prev) =>
+          prev ? applyProgressUpdate(prev, pending.resourceId, pending.watchedDuration) : prev,
+        );
+
+        pendingRef.current = null;
+      } catch {
+        pending.retryCount += 1;
+        retryPending();
+      }
+    }, delay);
+  };
+
+  const saveProgress = async (resourceId: string, watchedDuration: number) => {
+    try {
+      /**
+       * TODO: 서버 연동 원본 코드 (복구용)
+       * await updateLearnProgress({
+       *   resourceId,
+       *   watchedDuration,
+       * });
+       */
+
+      setProgressData((prev) =>
+        prev ? applyProgressUpdate(prev, resourceId, watchedDuration) : prev,
+      );
+
+      // mock 단계에서는 실제 네트워크 호출 없음
+      lastSavedDurationRef.current = watchedDuration;
+    } catch (e) {
+      console.error('[progress] save failed', e);
+    }
+  };
+
+  const saveProgressThrottled = (resourceId: string, watchedDuration: number) => {
+    const now = Date.now();
+
+    if (now - lastSavedAtRef.current < THROTTLE_INTERVAL) return;
+    if (Math.abs(watchedDuration - lastSavedDurationRef.current) < MIN_SAVE_DELTA) return;
+
+    lastSavedAtRef.current = now;
+    saveProgress(resourceId, watchedDuration);
+  };
+
+  const endedProgress = (resourceId: string, watchedDuration: number) => {
+    if (pendingRef.current) return;
+    saveProgress(resourceId, watchedDuration);
+  };
+
+  function applyProgressUpdate(
+    prev: LearnProgressResponse,
+    resourceId: string,
+    watchedDuration: number,
+  ): LearnProgressResponse {
+    const lectureProgresses = prev.lectureProgresses.map((p) => {
+      if (p.resourceId !== resourceId) return p;
+
+      const progressRate = Math.min(
+        100,
+        Math.round((watchedDuration / p.totalDurationSeconds) * 100),
+      );
+
+      return {
+        ...p,
+        watchedDuration,
+        currentProgressRate: progressRate,
+        isCompleted: progressRate >= 100,
+        lastWatchedAt: new Date().toISOString(),
+      };
+    });
+
+    return {
+      ...prev,
+      lectureProgresses,
+      lastVideoId: resourceId,
+      lastWatchedDuration: watchedDuration,
+      lastWatchedAt: new Date().toISOString(),
+    };
+  }
+
+  return {
+    progress,
+    lectureProgressMap,
+    resumeInfo,
+    overallProgressRate: progress?.overallProgressRate ?? 0,
+    saveProgress,
+    saveProgressThrottled,
+    endedProgress,
+    isLoading,
+    error,
+  };
+}

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
   CourseLearnProgress,
-  GetLearnProgressResponse,
+  UpdateProgressResponse,
   LectureProgressMapValue,
   ResumeInfo,
   PendingProgress,
@@ -16,7 +16,7 @@ import type {
 import { MOCK_LEARN_PROGRESS } from '@/mocks/learn.mock';
 
 export function useProgress(enrollmentId: string) {
-  const [progressData, setProgressData] = useState<GetLearnProgressResponse | null>(null);
+  const [progressData, setProgressData] = useState<UpdateProgressResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -161,10 +161,10 @@ export function useProgress(enrollmentId: string) {
 
   // 프론트에서 진도 상태를 계산/반영
   function applyProgressUpdate(
-    prev: GetLearnProgressResponse,
+    prev: UpdateProgressResponse,
     resourceId: string,
     watchedDuration: number,
-  ): GetLearnProgressResponse {
+  ): UpdateProgressResponse {
     const lectureProgresses = prev.lectureProgresses.map((p) => {
       if (p.resourceId !== resourceId) return p;
 

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -62,7 +62,7 @@ export function useProgress(enrollmentId: string) {
     );
   }, [progressData]);
 
-  const resumeInfo = useMemo<ProgressInfo | null>(() => {
+  const progressInfo = useMemo<ProgressInfo | null>(() => {
     if (!progressData?.lastVideoId) return null;
 
     return {
@@ -77,10 +77,10 @@ export function useProgress(enrollmentId: string) {
     return {
       enrollmentId: progressData.enrollmentId,
       overallProgressRate: progressData.progressRate,
-      resumeInfo,
+      progressInfo,
       lectureProgressMap,
     };
-  }, [progressData, resumeInfo, lectureProgressMap]);
+  }, [progressData, progressInfo, lectureProgressMap]);
 
   const lastSavedAtRef = useRef<number>(0); // 마지막 저장 시각 (throttle 용)
   const lastSavedDurationRef = useRef<number>(0); // 마지막으로 저장된 재생 위치 (delta 비교용)
@@ -194,7 +194,7 @@ export function useProgress(enrollmentId: string) {
   return {
     progress,
     lectureProgressMap,
-    resumeInfo,
+    progressInfo,
     overallProgressRate: progress?.overallProgressRate ?? 0,
     saveProgress,
     saveProgressThrottled,

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -143,7 +143,7 @@ export function useProgress(enrollmentId: string) {
   };
 
   // 재생 중 주기적 진도 저장
-  const saveProgressThrottled = (resourceId: string, watchedDuration: number) => {
+  const autoSaveProgress = (resourceId: string, watchedDuration: number) => {
     const now = Date.now();
 
     if (now - lastSavedAtRef.current < THROTTLE_INTERVAL) return;
@@ -197,7 +197,7 @@ export function useProgress(enrollmentId: string) {
     progressInfo,
     overallProgressRate: progress?.overallProgressRate ?? 0,
     saveProgress,
-    saveProgressThrottled,
+    autoSaveProgress,
     saveFinalProgressOnEnd,
     isLoading,
     error,

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -6,7 +6,7 @@ import type {
   CourseLearnProgress,
   UpdateProgressResponse,
   LectureProgressMapValue,
-  ResumeInfo,
+  ProgressInfo,
   PendingProgress,
 } from '@/domains/course/types/progress';
 
@@ -62,7 +62,7 @@ export function useProgress(enrollmentId: string) {
     );
   }, [progressData]);
 
-  const resumeInfo = useMemo<ResumeInfo | null>(() => {
+  const resumeInfo = useMemo<ProgressInfo | null>(() => {
     if (!progressData?.lastVideoId) return null;
 
     return {

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -154,7 +154,7 @@ export function useProgress(enrollmentId: string) {
   };
 
   // 영상 종료 시 최종 진도 저장
-  const endedProgress = (resourceId: string, watchedDuration: number) => {
+  const saveFinalProgressOnEnd = (resourceId: string, watchedDuration: number) => {
     if (pendingRef.current) return;
     saveProgress(resourceId, watchedDuration);
   };
@@ -198,7 +198,7 @@ export function useProgress(enrollmentId: string) {
     overallProgressRate: progress?.overallProgressRate ?? 0,
     saveProgress,
     saveProgressThrottled,
-    endedProgress,
+    saveFinalProgressOnEnd,
     isLoading,
     error,
   };

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
   CourseLearnProgress,
-  GetLearnLectureProgressResponse,
+  GetLearnProgressResponse,
   LectureProgressMapValue,
   ResumeInfo,
   PendingProgress,
@@ -16,7 +16,7 @@ import type {
 import { MOCK_LEARN_PROGRESS } from '@/mocks/learn.mock';
 
 export function useProgress(enrollmentId: string) {
-  const [progressData, setProgressData] = useState<GetLearnLectureProgressResponse | null>(null);
+  const [progressData, setProgressData] = useState<GetLearnProgressResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -161,10 +161,10 @@ export function useProgress(enrollmentId: string) {
 
   // 프론트에서 진도 상태를 계산/반영
   function applyProgressUpdate(
-    prev: GetLearnLectureProgressResponse,
+    prev: GetLearnProgressResponse,
     resourceId: string,
     watchedDuration: number,
-  ): GetLearnLectureProgressResponse {
+  ): GetLearnProgressResponse {
     const lectureProgresses = prev.lectureProgresses.map((p) => {
       if (p.resourceId !== resourceId) return p;
 

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -15,7 +15,7 @@ import type {
 
 import { MOCK_LEARN_PROGRESS } from '@/mocks/learn.mock';
 
-export function useCourseLearnProgress(enrollmentId: string) {
+export function useProgress(enrollmentId: string) {
   const [progressData, setProgressData] = useState<LearnProgressResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
@@ -23,27 +23,27 @@ export function useCourseLearnProgress(enrollmentId: string) {
   useEffect(() => {
     if (!enrollmentId) return;
 
-    /**
-     * TODO: 서버 연동 원본 코드 (복구용)
-     * async function fetchProgress() {
-     *   try {
-     *     setIsLoading(true);
-     *     const response = await getLearnProgress(enrollmentId);
-     *     setProgressData(response);
-     *   } catch (e) {
-     *     setError(e as Error);
-     *   } finally {
-     *     setIsLoading(false);
-     *   }
-     * }
-     *
-     * fetchProgress();
-     */
+    const fetchProgress = async () => {
+      try {
+        setIsLoading(true);
 
-    // TODO: UI 검증용 mock 데이터
-    setIsLoading(true);
-    setProgressData(MOCK_LEARN_PROGRESS);
-    setIsLoading(false);
+        if (process.env.NODE_ENV === 'development') {
+          // UI 검증용 mock
+          setProgressData(MOCK_LEARN_PROGRESS);
+          return;
+        }
+
+        // TODO: 실제 서버 연동
+        // const response = await getLearnProgress(enrollmentId);
+        // setProgressData(response);
+      } catch (e) {
+        setError(e as Error);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchProgress();
   }, [enrollmentId]);
 
   const lectureProgressMap = useMemo<Map<string, LectureProgressMapValue>>(() => {
@@ -82,15 +82,16 @@ export function useCourseLearnProgress(enrollmentId: string) {
     };
   }, [progressData, resumeInfo, lectureProgressMap]);
 
-  const lastSavedAtRef = useRef<number>(0);
-  const lastSavedDurationRef = useRef<number>(0);
+  const lastSavedAtRef = useRef<number>(0); // 마지막 저장 시각 (throttle 용)
+  const lastSavedDurationRef = useRef<number>(0); // 마지막으로 저장된 재생 위치 (delta 비교용)
 
-  const pendingRef = useRef<PendingProgress | null>(null);
+  const pendingRef = useRef<PendingProgress | null>(null); // 저장 실패 시 재시도 대상
 
-  const THROTTLE_INTERVAL = 10;
-  const MIN_SAVE_DELTA = 3;
-  const RETRY_DELAYS = [2000, 5000, 15000];
+  const THROTTLE_INTERVAL = 10; // 저장 최소 호출 간격 (ms)
+  const MIN_SAVE_DELTA = 3; // 저장할 최소 재생 시간 변화량 (초)
+  const RETRY_DELAYS = [2000, 5000, 15000]; // 저장 실패 시 재시도 간격 (ms)
 
+  // 저장 실패한 진도를 재시도
   const retryPending = () => {
     const pending = pendingRef.current;
     if (!pending) return;
@@ -119,6 +120,7 @@ export function useCourseLearnProgress(enrollmentId: string) {
     }, delay);
   };
 
+  // 진도 즉시 저장
   const saveProgress = async (resourceId: string, watchedDuration: number) => {
     try {
       /**
@@ -140,6 +142,7 @@ export function useCourseLearnProgress(enrollmentId: string) {
     }
   };
 
+  // 재생 중 주기적 진도 저장
   const saveProgressThrottled = (resourceId: string, watchedDuration: number) => {
     const now = Date.now();
 
@@ -150,11 +153,13 @@ export function useCourseLearnProgress(enrollmentId: string) {
     saveProgress(resourceId, watchedDuration);
   };
 
+  // 영상 종료 시 최종 진도 저장
   const endedProgress = (resourceId: string, watchedDuration: number) => {
     if (pendingRef.current) return;
     saveProgress(resourceId, watchedDuration);
   };
 
+  // 프론트에서 진도 상태를 계산/반영
   function applyProgressUpdate(
     prev: LearnProgressResponse,
     resourceId: string,

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -4,7 +4,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import type {
   CourseLearnProgress,
-  LearnProgressResponse,
+  GetLearnLectureProgressResponse,
   LectureProgressMapValue,
   ResumeInfo,
   PendingProgress,
@@ -16,7 +16,7 @@ import type {
 import { MOCK_LEARN_PROGRESS } from '@/mocks/learn.mock';
 
 export function useProgress(enrollmentId: string) {
-  const [progressData, setProgressData] = useState<LearnProgressResponse | null>(null);
+  const [progressData, setProgressData] = useState<GetLearnLectureProgressResponse | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<Error | null>(null);
 
@@ -161,10 +161,10 @@ export function useProgress(enrollmentId: string) {
 
   // 프론트에서 진도 상태를 계산/반영
   function applyProgressUpdate(
-    prev: LearnProgressResponse,
+    prev: GetLearnLectureProgressResponse,
     resourceId: string,
     watchedDuration: number,
-  ): LearnProgressResponse {
+  ): GetLearnLectureProgressResponse {
     const lectureProgresses = prev.lectureProgresses.map((p) => {
       if (p.resourceId !== resourceId) return p;
 

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -38,7 +38,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     handleLectureClick,
     moveToNextLecture,
   } = useCourseLearn(enrollmentId, { start });
-  const { progressInfo, saveProgressThrottled, saveFinalProgressOnEnd, lectureProgressMap } =
+  const { progressInfo, autoSaveProgress, saveFinalProgressOnEnd, lectureProgressMap } =
     useProgress(enrollmentId);
 
   const totalLectures = useMemo(() => {
@@ -127,7 +127,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
                     moveToNextLecture();
                   }}
                   onTimeUpdate={(e) => {
-                    saveProgressThrottled(
+                    autoSaveProgress(
                       currentLecture.resourceId,
                       Math.floor(e.currentTarget.currentTime),
                     );

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -38,7 +38,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     handleLectureClick,
     moveToNextLecture,
   } = useCourseLearn(enrollmentId, { start });
-  const { resumeInfo, saveProgressThrottled, endedProgress, lectureProgressMap } =
+  const { progressInfo, saveProgressThrottled, endedProgress, lectureProgressMap } =
     useProgress(enrollmentId);
 
   const totalLectures = useMemo(() => {
@@ -66,14 +66,14 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     const video = videoRef.current;
     if (!video) return;
     if (!currentLecture) return;
-    if (!resumeInfo) return;
+    if (!progressInfo) return;
     if (hasSeekedRef.current) return;
 
-    if (resumeInfo.lectureId !== currentLecture.id) return;
+    if (progressInfo.lectureId !== currentLecture.id) return;
 
     const handleLoadedMetadata = () => {
-      if (resumeInfo.resumeAt < video.duration) {
-        video.currentTime = resumeInfo.resumeAt;
+      if (progressInfo.resumeAt < video.duration) {
+        video.currentTime = progressInfo.resumeAt;
       }
       hasSeekedRef.current = true;
     };
@@ -82,7 +82,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     return () => {
       video.removeEventListener('loadedmetadata', handleLoadedMetadata);
     };
-  }, [currentLecture?.id, resumeInfo]);
+  }, [currentLecture?.id, progressInfo]);
 
   if (!courseData || !currentLecture) {
     return <div className={styles['course-learn__loading']}>강의를 불러오는 중입니다...</div>;

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -12,7 +12,7 @@ import {
 import { useRef, useEffect, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCourseLearn } from '@/domains/course/hooks/useCourseLearn';
-import { useCourseLearnProgress } from '@/domains/course/hooks/useCourseLearnProgress';
+import { useProgress } from '@/domains/course/hooks/useProgress';
 import styles from '@/app/courses/[id]/learn/CourseLearnPage.module.css';
 import { formatLectureDuration } from '@/domains/course/utils/formatDuration';
 import { formatAbsoluteUrl } from '../utils/formatAbsoluteUrl';
@@ -39,7 +39,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     moveToNextLecture,
   } = useCourseLearn(enrollmentId, { start });
   const { resumeInfo, saveProgressThrottled, endedProgress, lectureProgressMap } =
-    useCourseLearnProgress(enrollmentId);
+    useProgress(enrollmentId);
 
   const totalLectures = useMemo(() => {
     if (!courseData) return 0;

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -38,7 +38,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     handleLectureClick,
     moveToNextLecture,
   } = useCourseLearn(enrollmentId, { start });
-  const { progressInfo, saveProgressThrottled, endedProgress, lectureProgressMap } =
+  const { progressInfo, saveProgressThrottled, saveFinalProgressOnEnd, lectureProgressMap } =
     useProgress(enrollmentId);
 
   const totalLectures = useMemo(() => {
@@ -123,7 +123,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
                   autoPlay
                   onEnded={() => {
                     if (!currentLecture.duration) return;
-                    endedProgress(currentLecture.resourceId, currentLecture.duration);
+                    saveFinalProgressOnEnd(currentLecture.resourceId, currentLecture.duration);
                     moveToNextLecture();
                   }}
                   onTimeUpdate={(e) => {
@@ -149,7 +149,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
                 {currentLecture.pdfUrl && (
                   <a href={formatAbsoluteUrl(currentLecture.pdfUrl)} download>
                     <button
-                      onClick={() => endedProgress(currentLecture.id, 0)}
+                      onClick={() => saveFinalProgressOnEnd(currentLecture.id, 0)}
                       className={styles['course-learn__brand-btn']}
                     >
                       <Download className={styles['course-learn__icon']} /> PDF 다운로드

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -12,6 +12,7 @@ import {
 import { useRef, useEffect, useMemo } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCourseLearn } from '@/domains/course/hooks/useCourseLearn';
+import { useCourseLearnProgress } from '@/domains/course/hooks/useCourseLearnProgress';
 import styles from '@/app/courses/[id]/learn/CourseLearnPage.module.css';
 import { formatLectureDuration } from '@/domains/course/utils/formatDuration';
 import { formatAbsoluteUrl } from '../utils/formatAbsoluteUrl';
@@ -34,15 +35,11 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     currentLecture,
     openSections,
     toggleSection,
-    handleVideoEnded,
-    handleVideoTimeUpdate,
     handleLectureClick,
-    markPdfCompleted,
-    learnData,
+    moveToNextLecture,
   } = useCourseLearn(enrollmentId, { start });
-
-  const lastVideoId = learnData?.progress?.lastVideoId ?? null;
-  const lastWatchedDuration = learnData?.progress?.lastWatchedDuration ?? 0;
+  const { resumeInfo, saveProgressThrottled, endedProgress, lectureProgressMap } =
+    useCourseLearnProgress(enrollmentId);
 
   const totalLectures = useMemo(() => {
     if (!courseData) return 0;
@@ -51,8 +48,14 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
 
   const completedLectures = useMemo(() => {
     if (!courseData) return 0;
-    return courseData.sections.flatMap((s) => s.lectures).filter((l) => l.completed).length;
-  }, [courseData]);
+
+    return courseData.sections
+      .flatMap((s) => s.lectures)
+      .filter((lecture) => {
+        const progress = lectureProgressMap.get(lecture.resourceId);
+        return progress?.completed === true;
+      }).length;
+  }, [courseData, lectureProgressMap]);
 
   useEffect(() => {
     if (!currentLecture) return;
@@ -63,14 +66,14 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     const video = videoRef.current;
     if (!video) return;
     if (!currentLecture) return;
-    if (!lastWatchedDuration) return;
+    if (!resumeInfo) return;
     if (hasSeekedRef.current) return;
 
-    if (lastVideoId !== currentLecture.id) return;
+    if (resumeInfo.lectureId !== currentLecture.id) return;
 
     const handleLoadedMetadata = () => {
-      if (lastWatchedDuration < video.duration) {
-        video.currentTime = lastWatchedDuration;
+      if (resumeInfo.resumeAt < video.duration) {
+        video.currentTime = resumeInfo.resumeAt;
       }
       hasSeekedRef.current = true;
     };
@@ -79,11 +82,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
     return () => {
       video.removeEventListener('loadedmetadata', handleLoadedMetadata);
     };
-  }, [currentLecture?.id, lastWatchedDuration, lastVideoId]);
-
-  if (!courseData || !currentLecture) {
-    return <div className={styles['course-learn__loading']}>강의를 불러오는 중입니다...</div>;
-  }
+  }, [currentLecture?.id, resumeInfo]);
 
   if (!courseData || !currentLecture) {
     return <div className={styles['course-learn__loading']}>강의를 불러오는 중입니다...</div>;
@@ -122,8 +121,17 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
                   key={currentLecture.id}
                   controls
                   autoPlay
-                  onEnded={handleVideoEnded}
-                  onTimeUpdate={(e) => handleVideoTimeUpdate(e.currentTarget.currentTime)}
+                  onEnded={() => {
+                    if (!currentLecture.duration) return;
+                    endedProgress(currentLecture.resourceId, currentLecture.duration);
+                    moveToNextLecture();
+                  }}
+                  onTimeUpdate={(e) => {
+                    saveProgressThrottled(
+                      currentLecture.resourceId,
+                      Math.floor(e.currentTarget.currentTime),
+                    );
+                  }}
                 >
                   <source src={formatAbsoluteUrl(currentLecture.videoUrl)} type="video/mp4" />
                   브라우저가 비디오를 지원하지 않습니다.
@@ -141,7 +149,7 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
                 {currentLecture.pdfUrl && (
                   <a href={formatAbsoluteUrl(currentLecture.pdfUrl)} download>
                     <button
-                      onClick={() => markPdfCompleted(currentLecture)}
+                      onClick={() => endedProgress(currentLecture.id, 0)}
                       className={styles['course-learn__brand-btn']}
                     >
                       <Download className={styles['course-learn__icon']} /> PDF 다운로드
@@ -201,35 +209,41 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
 
                 {openSections.includes(section.id) && (
                   <div className={styles['course-learn__section-content']}>
-                    {section.lectures.map((lecture) => (
-                      <button
-                        key={lecture.id}
-                        onClick={() => handleLectureClick(lecture)}
-                        className={`${styles['course-learn__lecture-btn']} ${
-                          currentLecture.id === lecture.id
-                            ? styles['course-learn__lecture-btn--active']
-                            : ''
-                        }`}
-                      >
-                        <div className={styles['course-learn__lecture-icon']}>
-                          {lecture.completed ? (
-                            <CheckCircle className={styles['course-learn__icon']} />
-                          ) : lecture.type === 'VIDEO' ? (
-                            <Play className={styles['course-learn__icon']} />
-                          ) : (
-                            <FileText className={styles['course-learn__icon']} />
-                          )}
-                        </div>
-                        <div className={styles['course-learn__lecture-text']}>
-                          <p className={styles['course-learn__lecture-title']}>{lecture.title}</p>
-                          <p className={styles['course-learn__lecture-meta']}>
-                            {lecture.type === 'VIDEO'
-                              ? formatLectureDuration(lecture.duration)
-                              : 'PDF'}
-                          </p>
-                        </div>
-                      </button>
-                    ))}
+                    {section.lectures.map((lecture) => {
+                      const progress = lectureProgressMap.get(lecture.resourceId);
+                      const completed = progress?.completed === true;
+
+                      return (
+                        <button
+                          key={lecture.id}
+                          onClick={() => handleLectureClick(lecture)}
+                          className={`${styles['course-learn__lecture-btn']} ${
+                            currentLecture.id === lecture.id
+                              ? styles['course-learn__lecture-btn--active']
+                              : ''
+                          }`}
+                        >
+                          <div className={styles['course-learn__lecture-icon']}>
+                            {completed ? (
+                              <CheckCircle className={styles['course-learn__icon']} />
+                            ) : lecture.type === 'VIDEO' ? (
+                              <Play className={styles['course-learn__icon']} />
+                            ) : (
+                              <FileText className={styles['course-learn__icon']} />
+                            )}
+                          </div>
+
+                          <div className={styles['course-learn__lecture-text']}>
+                            <p className={styles['course-learn__lecture-title']}>{lecture.title}</p>
+                            <p className={styles['course-learn__lecture-meta']}>
+                              {lecture.type === 'VIDEO'
+                                ? formatLectureDuration(lecture.duration)
+                                : 'PDF'}
+                            </p>
+                          </div>
+                        </button>
+                      );
+                    })}
                   </div>
                 )}
               </div>

--- a/src/domains/course/services/learnService.ts
+++ b/src/domains/course/services/learnService.ts
@@ -1,7 +1,7 @@
 import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
 import type {
-  GetLearnLectureProgressResponse,
-  UpdateLearnProgressRequest,
+  GetLearnProgressResponse,
+  UpdateProgressRequest,
 } from '@/domains/course/types/progress';
 import { getApi, patchApi } from '@/shared/lib/api/fetchApi';
 
@@ -16,18 +16,13 @@ export async function getLearnEnrollment(enrollmentId: string): Promise<LearnEnr
 }
 
 // 학습 이력 조회
-export async function getLearnProgress(
-  enrollmentId: string,
-): Promise<GetLearnLectureProgressResponse> {
+export async function getLearnProgress(enrollmentId: string): Promise<GetLearnProgressResponse> {
   return getApi(`/api/progresses/${enrollmentId}`, { cache: 'no-store' });
 }
 
 // 진도율 갱신
 export async function updateLearnProgress(
-  payload: UpdateLearnProgressRequest,
-): Promise<GetLearnLectureProgressResponse> {
-  return patchApi<GetLearnLectureProgressResponse>(
-    `/api/progresses/${payload.resourceId}`,
-    payload,
-  );
+  payload: UpdateProgressRequest,
+): Promise<GetLearnProgressResponse> {
+  return patchApi<GetLearnProgressResponse>(`/api/progresses/${payload.resourceId}`, payload);
 }

--- a/src/domains/course/services/learnService.ts
+++ b/src/domains/course/services/learnService.ts
@@ -1,5 +1,8 @@
 import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
-import type { LearnProgressResponse, LearnProgressRequest } from '@/domains/course/types/progress';
+import type {
+  GetLearnLectureProgressResponse,
+  UpdateLearnProgressRequest,
+} from '@/domains/course/types/progress';
 import { getApi, patchApi } from '@/shared/lib/api/fetchApi';
 
 // 강좌 정보 조회
@@ -13,13 +16,18 @@ export async function getLearnEnrollment(enrollmentId: string): Promise<LearnEnr
 }
 
 // 학습 이력 조회
-export async function getLearnProgress(enrollmentId: string): Promise<LearnProgressResponse> {
+export async function getLearnProgress(
+  enrollmentId: string,
+): Promise<GetLearnLectureProgressResponse> {
   return getApi(`/api/progresses/${enrollmentId}`, { cache: 'no-store' });
 }
 
 // 진도율 갱신
 export async function updateLearnProgress(
-  payload: LearnProgressRequest,
-): Promise<LearnProgressResponse> {
-  return patchApi<LearnProgressResponse>(`/api/progresses/${payload.resourceId}`, payload);
+  payload: UpdateLearnProgressRequest,
+): Promise<GetLearnLectureProgressResponse> {
+  return patchApi<GetLearnLectureProgressResponse>(
+    `/api/progresses/${payload.resourceId}`,
+    payload,
+  );
 }

--- a/src/domains/course/services/learnService.ts
+++ b/src/domains/course/services/learnService.ts
@@ -1,9 +1,5 @@
-import type {
-  LearnCourseResponse,
-  LearnEnrollmentResponse,
-  LearnProgressResponse,
-  LearnProgressRequest,
-} from '@/domains/course/types/learn';
+import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
+import type { LearnProgressResponse, LearnProgressRequest } from '@/domains/course/types/progress';
 import { getApi, patchApi } from '@/shared/lib/api/fetchApi';
 
 // 강좌 정보 조회

--- a/src/domains/course/services/learnService.ts
+++ b/src/domains/course/services/learnService.ts
@@ -1,6 +1,6 @@
 import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
 import type {
-  GetLearnProgressResponse,
+  UpdateProgressResponse,
   UpdateProgressRequest,
 } from '@/domains/course/types/progress';
 import { getApi, patchApi } from '@/shared/lib/api/fetchApi';
@@ -16,13 +16,13 @@ export async function getLearnEnrollment(enrollmentId: string): Promise<LearnEnr
 }
 
 // 학습 이력 조회
-export async function getLearnProgress(enrollmentId: string): Promise<GetLearnProgressResponse> {
+export async function getLearnProgress(enrollmentId: string): Promise<UpdateProgressResponse> {
   return getApi(`/api/progresses/${enrollmentId}`, { cache: 'no-store' });
 }
 
 // 진도율 갱신
 export async function updateLearnProgress(
   payload: UpdateProgressRequest,
-): Promise<GetLearnProgressResponse> {
-  return patchApi<GetLearnProgressResponse>(`/api/progresses/${payload.resourceId}`, payload);
+): Promise<UpdateProgressResponse> {
+  return patchApi<UpdateProgressResponse>(`/api/progresses/${payload.resourceId}`, payload);
 }

--- a/src/domains/course/types/learn.ts
+++ b/src/domains/course/types/learn.ts
@@ -1,5 +1,6 @@
 import { EnrollmentStatus } from '@/domains/user/types/enrollment';
 
+// API: Course / Enrollment
 export type LearnLectureResourceResponse = {
   resourceId: string;
   resourceType: 'VIDEO' | 'PDF';
@@ -55,47 +56,22 @@ export type LearnEnrollmentResponse = {
   expiredAt: string;
 };
 
-export type LearnLectureProgressResponse = {
-  resourceId: string;
-  title: string;
-  currentProgressRate: number;
-  watchedDuration: number;
-  totalDurationSeconds: number;
-  isCompleted: boolean;
-  lastWatchedAt: string | null;
-};
-
-export type LearnProgressResponse = {
-  enrollmentId: string;
-  progressRate: number;
-  lastVideoId: string | null;
-  lastWatchedDuration: number;
-  lastWatchedAt: string | null;
-  lectureProgresses: LearnLectureProgressResponse[];
-  updatedAt: string;
-};
-
-export type LearnProgressRequest = {
-  resourceId: string;
-  watchedDuration: number;
-};
-
+// Domain: Course + Enrollment
 export type CourseLearn = {
   course: LearnCourseResponse;
   enrollment: LearnEnrollmentResponse;
-  progress: LearnProgressResponse;
 };
 
+// UI Types (Learn Page)
 export type UILecture = {
   id: string;
+  resourceId: string;
   title: string;
   description?: string;
   duration: number;
   type: 'VIDEO' | 'PDF';
   videoUrl?: string;
   pdfUrl?: string;
-  completed: boolean;
-  isCurrent: boolean;
 };
 
 export type UISection = {

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -1,5 +1,5 @@
 // API: GET /api/progresses/{enrollmentId}
-export type LearnLectureProgressResponse = {
+export type GetGetLearnLectureProgressResponse = {
   resourceId: string;
   title: string;
   currentProgressRate: number;
@@ -9,18 +9,18 @@ export type LearnLectureProgressResponse = {
   lastWatchedAt: string | null;
 };
 
-export type LearnProgressResponse = {
+export type GetLearnLectureProgressResponse = {
   enrollmentId: string;
   progressRate: number;
   lastVideoId: string | null;
   lastWatchedDuration: number;
   lastWatchedAt: string | null;
-  lectureProgresses: LearnLectureProgressResponse[];
+  lectureProgresses: GetGetLearnLectureProgressResponse[];
   updatedAt: string;
 };
 
 // API: PATCH /api/progresses
-export type LearnProgressRequest = {
+export type UpdateLearnProgressRequest = {
   resourceId: string;
   watchedDuration: number;
 };

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -26,7 +26,7 @@ export type UpdateProgressRequest = {
 };
 
 // 이어보기 정보
-export type ResumeInfo = {
+export type ProgressInfo = {
   lectureId: string;
   resumeAt: number;
 };
@@ -43,7 +43,7 @@ export type LectureProgressMapValue = {
 export type CourseLearnProgress = {
   enrollmentId: string;
   overallProgressRate: number;
-  resumeInfo: ResumeInfo | null;
+  resumeInfo: ProgressInfo | null;
   lectureProgressMap: Map<string, LectureProgressMapValue>;
 };
 

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -39,7 +39,7 @@ export type LectureProgressMapValue = {
   completed: boolean;
 };
 
-// useCourseLearnProgress 반환 타입
+// useProgress 반환 타입
 export type CourseLearnProgress = {
   enrollmentId: string;
   overallProgressRate: number;

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -9,7 +9,7 @@ export type GetProgressResponse = {
   lastWatchedAt: string | null;
 };
 
-export type GetLearnProgressResponse = {
+export type UpdateProgressResponse = {
   enrollmentId: string;
   progressRate: number;
   lastVideoId: string | null;

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -1,5 +1,5 @@
 // API: GET /api/progresses/{enrollmentId}
-export type GetGetLearnLectureProgressResponse = {
+export type GetProgressResponse = {
   resourceId: string;
   title: string;
   currentProgressRate: number;
@@ -9,18 +9,18 @@ export type GetGetLearnLectureProgressResponse = {
   lastWatchedAt: string | null;
 };
 
-export type GetLearnLectureProgressResponse = {
+export type GetLearnProgressResponse = {
   enrollmentId: string;
   progressRate: number;
   lastVideoId: string | null;
   lastWatchedDuration: number;
   lastWatchedAt: string | null;
-  lectureProgresses: GetGetLearnLectureProgressResponse[];
+  lectureProgresses: GetProgressResponse[];
   updatedAt: string;
 };
 
 // API: PATCH /api/progresses
-export type UpdateLearnProgressRequest = {
+export type UpdateProgressRequest = {
   resourceId: string;
   watchedDuration: number;
 };

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -43,7 +43,7 @@ export type LectureProgressMapValue = {
 export type CourseLearnProgress = {
   enrollmentId: string;
   overallProgressRate: number;
-  resumeInfo: ProgressInfo | null;
+  progressInfo: ProgressInfo | null;
   lectureProgressMap: Map<string, LectureProgressMapValue>;
 };
 

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -1,5 +1,6 @@
-export type LectureProgress = {
-  resourceId: number;
+// API: GET /api/progresses/{enrollmentId}
+export type LearnLectureProgressResponse = {
+  resourceId: string;
   title: string;
   currentProgressRate: number;
   watchedDuration: number;
@@ -8,30 +9,46 @@ export type LectureProgress = {
   lastWatchedAt: string | null;
 };
 
-export type CourseProgressDetail = {
-  enrollmentId: number;
-  overallProgressRate: number;
-
-  lastWatchedVideoId: number | null;
-  lastWatchedDurationOfLastVideo: number | null;
+export type LearnProgressResponse = {
+  enrollmentId: string;
+  progressRate: number;
+  lastVideoId: string | null;
+  lastWatchedDuration: number;
   lastWatchedAt: string | null;
-
-  lectureProgresses: LectureProgress[];
+  lectureProgresses: LearnLectureProgressResponse[];
+  updatedAt: string;
 };
 
-export type LearnLecture = {
-  id: number;
-  title: string;
-  type: 'VIDEO' | 'PDF';
-
-  duration?: number;
+// API: PATCH /api/progresses
+export type LearnProgressRequest = {
+  resourceId: string;
   watchedDuration: number;
-  progressRate: number;
+};
 
+// 이어보기 정보
+export type ResumeInfo = {
+  lectureId: string;
+  resumeAt: number;
+};
+
+// Map에 들어갈 progress 값
+export type LectureProgressMapValue = {
+  progressRate: number;
+  watchedDuration: number;
+  totalDurationSeconds: number;
   completed: boolean;
 };
 
-export type ResumeInfo = {
-  lectureId: number | null;
-  startTime: number;
+// useCourseLearnProgress 반환 타입
+export type CourseLearnProgress = {
+  enrollmentId: string;
+  overallProgressRate: number;
+  resumeInfo: ResumeInfo | null;
+  lectureProgressMap: Map<string, LectureProgressMapValue>;
+};
+
+export type PendingProgress = {
+  resourceId: string;
+  watchedDuration: number;
+  retryCount: number;
 };

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -1,4 +1,3 @@
-// API: GET /api/progresses/{enrollmentId}
 export type GetProgressResponse = {
   resourceId: string;
   title: string;
@@ -19,7 +18,6 @@ export type UpdateProgressResponse = {
   updatedAt: string;
 };
 
-// API: PATCH /api/progresses
 export type UpdateProgressRequest = {
   resourceId: string;
   watchedDuration: number;
@@ -47,6 +45,7 @@ export type CourseLearnProgress = {
   lectureProgressMap: Map<string, LectureProgressMapValue>;
 };
 
+// 진도율 갱신 보류
 export type PendingProgress = {
   resourceId: string;
   watchedDuration: number;

--- a/src/domains/course/utils/mapCourse.ts
+++ b/src/domains/course/utils/mapCourse.ts
@@ -1,11 +1,5 @@
-import type {
-  LearnCourseResponse,
-  UILecture,
-  UISection,
-  UICourse,
-} from '@/domains/course/types/learn';
+import type { LearnCourseResponse, UICourse } from '@/domains/course/types/learn';
 import type { LectureProgressMapValue } from '@/domains/course/types/progress';
-import { useCourseLearnProgress } from '@/domains/course/hooks/useCourseLearnProgress';
 
 export function mapCourse(
   course: LearnCourseResponse,

--- a/src/domains/course/utils/mapCourse.ts
+++ b/src/domains/course/utils/mapCourse.ts
@@ -4,8 +4,13 @@ import type {
   UISection,
   UICourse,
 } from '@/domains/course/types/learn';
+import type { LectureProgressMapValue } from '@/domains/course/types/progress';
+import { useCourseLearnProgress } from '@/domains/course/hooks/useCourseLearnProgress';
 
-export function mapCourse(course: LearnCourseResponse, completedLectureIds: Set<string>): UICourse {
+export function mapCourse(
+  course: LearnCourseResponse,
+  lectureProgressMap: Map<string, LectureProgressMapValue>,
+): UICourse {
   return {
     courseId: course.courseId,
     title: course.title,
@@ -16,30 +21,36 @@ export function mapCourse(course: LearnCourseResponse, completedLectureIds: Set<
     price: course.price,
     status: course.status,
     thumbnailUrl: course.thumbnailUrl,
-
     instructor: course.instructor,
 
-    sections: course.sections.map<UISection>((section) => ({
-      id: section.sectionId,
-      title: section.title,
-      order: section.order,
+    sections: course.sections
+      .slice()
+      .sort((a, b) => a.order - b.order)
+      .map((section) => ({
+        id: section.sectionId,
+        title: section.title,
+        order: section.order,
 
-      lectures: section.lectures.map<UILecture>((lecture) => {
-        const isVideo = lecture.resource.resourceType === 'VIDEO';
+        lectures: section.lectures
+          .slice()
+          .sort((a, b) => a.orderIndex - b.orderIndex)
+          .map((lecture) => {
+            const progress = lectureProgressMap.get(lecture.resource.resourceId);
 
-        return {
-          id: lecture.lectureId,
-          title: lecture.title,
-          duration: lecture.totalDurationSeconds,
-          type: lecture.resource.resourceType,
-
-          videoUrl: isVideo ? lecture.resource.fileUrl : undefined,
-          pdfUrl: !isVideo ? lecture.resource.fileUrl : undefined,
-
-          completed: completedLectureIds.has(lecture.lectureId),
-          isCurrent: false,
-        };
-      }),
-    })),
+            return {
+              id: lecture.lectureId,
+              resourceId: lecture.resource.resourceId,
+              title: lecture.title,
+              duration: lecture.totalDurationSeconds,
+              type: lecture.resource.resourceType,
+              videoUrl:
+                lecture.resource.resourceType === 'VIDEO' ? lecture.resource.fileUrl : undefined,
+              pdfUrl:
+                lecture.resource.resourceType === 'PDF' ? lecture.resource.fileUrl : undefined,
+              completed: progress?.completed ?? false,
+              isCurrent: false,
+            };
+          }),
+      })),
   };
 }

--- a/src/domains/user/pages/EnrollmentClientPage.tsx
+++ b/src/domains/user/pages/EnrollmentClientPage.tsx
@@ -55,6 +55,12 @@ export default function EnrollmentClientPage() {
       <div className={styles['enrollment-section__list']}>
         {items.map((item) => {
           const hasProgress = (item.progressRate ?? 0) > 0;
+          const buttonLabel = hasProgress ? '이어보기' : '처음부터';
+          const buttonHref = hasProgress
+            ? `/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}`
+            : `/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}&start=first`;
+          const buttonClass = hasProgress ? styles['btn-primary'] : styles['btn-secondary'];
+
           return (
             <div key={item.enrollmentId} className={styles['enrollment-card']}>
               <div className={styles['enrollment__link']}>
@@ -64,34 +70,22 @@ export default function EnrollmentClientPage() {
                     {item.categories?.join(' / ') ?? '카테고리 없음'}
                   </p>
                 </div>
+
                 <div className={styles['enrollment-card__actions']}>
-                  <Link
-                    href={`/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}&start=first`}
-                    className={styles['btn-secondary']}
-                  >
-                    처음부터
+                  <Link href={buttonHref} className={buttonClass}>
+                    {buttonLabel}
                   </Link>
-                  {hasProgress && (
-                    <Link
-                      href={`/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}`}
-                      className={styles['btn-primary']}
-                    >
-                      이어보기
-                    </Link>
-                  )}
                 </div>
               </div>
 
-              <div className={styles['progress']} aria-label={`${item.progressRate ?? 0}%`}>
+              <div className={styles['progress']}>
                 <div
                   className={styles['progress__bar']}
                   style={{ width: `${item.progressRate ?? 0}%` }}
                 />
               </div>
 
-              <span
-                className={styles['enrollment-card__percent']}
-              >{`${item.progressRate ?? 0}%`}</span>
+              <span className={styles['enrollment-card__percent']}>{item.progressRate ?? 0}%</span>
             </div>
           );
         })}

--- a/src/domains/user/pages/EnrollmentClientPage.tsx
+++ b/src/domains/user/pages/EnrollmentClientPage.tsx
@@ -65,10 +65,12 @@ export default function EnrollmentClientPage() {
             <div key={item.enrollmentId} className={styles['enrollment-card']}>
               <div className={styles['enrollment__link']}>
                 <div className={styles['enrollment__text']}>
-                  <h3 className={styles['enrollment__title']}>{item.courseName}</h3>
-                  <p className={styles['enrollment__category']}>
-                    {item.categories?.join(' / ') ?? '카테고리 없음'}
-                  </p>
+                  <Link href={`/courses/${item.courseId}`}>
+                    <h3 className={styles['enrollment__title']}>{item.courseName}</h3>
+                    <p className={styles['enrollment__category']}>
+                      {item.categories?.join(' / ') ?? '카테고리 없음'}
+                    </p>
+                  </Link>
                 </div>
 
                 <div className={styles['enrollment-card__actions']}>

--- a/src/mocks/enrollmentList.mock.ts
+++ b/src/mocks/enrollmentList.mock.ts
@@ -1,5 +1,4 @@
 import type { EnrollmentListResponse } from '@/domains/user/types/enrollment';
-import { mockLearnProgress } from './learn.mock';
 
 export const MOCK_ENROLLMENT_LIST: EnrollmentListResponse = {
   content: [

--- a/src/mocks/enrollmentList.mock.ts
+++ b/src/mocks/enrollmentList.mock.ts
@@ -4,12 +4,12 @@ import { mockLearnProgress } from './learn.mock';
 export const MOCK_ENROLLMENT_LIST: EnrollmentListResponse = {
   content: [
     {
-      enrollmentId: 'mock-enrollment-1',
-      userId: 'u-001',
-      courseId: '2001',
+      enrollmentId: '5001',
+      userId: 'user_001',
+      courseId: '2002',
       courseName: '스프링 부트 완벽 가이드',
       status: 'ENROLLED',
-      progressRate: 0,
+      progressRate: 5,
       categories: ['백엔드'],
       expiredAt: '2026-01-01T09:00:00',
     },

--- a/src/mocks/learn.mock.ts
+++ b/src/mocks/learn.mock.ts
@@ -1,5 +1,5 @@
 import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
-import { GetLearnProgressResponse } from '@/domains/course/types/progress';
+import { UpdateProgressResponse } from '@/domains/course/types/progress';
 
 export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
   '2002': {
@@ -104,7 +104,7 @@ export const MOCK_LEARN_ENROLLMENT: LearnEnrollmentResponse = {
   expiredAt: '2026-01-01T09:00:00',
 };
 
-export const MOCK_LEARN_PROGRESS: GetLearnProgressResponse = {
+export const MOCK_LEARN_PROGRESS: UpdateProgressResponse = {
   enrollmentId: '5001',
   progressRate: 5,
 

--- a/src/mocks/learn.mock.ts
+++ b/src/mocks/learn.mock.ts
@@ -1,4 +1,5 @@
 import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
+import { LearnProgressResponse } from '@/domains/course/types/progress';
 
 export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
   '2002': {
@@ -103,7 +104,7 @@ export const MOCK_LEARN_ENROLLMENT: LearnEnrollmentResponse = {
   expiredAt: '2026-01-01T09:00:00',
 };
 
-export const MOCK_LEARN_PROGRESS = {
+export const MOCK_LEARN_PROGRESS: LearnProgressResponse = {
   enrollmentId: '5001',
   progressRate: 5,
 
@@ -114,6 +115,7 @@ export const MOCK_LEARN_PROGRESS = {
   lectureProgresses: [
     {
       resourceId: '3001',
+      title: 'JPA란?',
       currentProgressRate: 50,
       watchedDuration: 5,
       totalDurationSeconds: 10,
@@ -122,6 +124,7 @@ export const MOCK_LEARN_PROGRESS = {
     },
     {
       resourceId: '3002',
+      title: '엔티티 매핑',
       currentProgressRate: 0,
       watchedDuration: 0,
       totalDurationSeconds: 10,
@@ -130,19 +133,21 @@ export const MOCK_LEARN_PROGRESS = {
     },
     {
       resourceId: '3003',
+      title: '엔티티 매핑',
       currentProgressRate: 0,
       watchedDuration: 0,
       totalDurationSeconds: 10,
       isCompleted: false,
-      lastWatchedAt: null,
+      lastWatchedAt: '2025-12-02T09:40:00',
     },
     {
       resourceId: '3004',
+      title: '엔티티 매핑',
       currentProgressRate: 0,
       watchedDuration: 0,
       totalDurationSeconds: 10,
       isCompleted: false,
-      lastWatchedAt: null,
+      lastWatchedAt: '2025-12-02T09:40:00',
     },
   ],
 

--- a/src/mocks/learn.mock.ts
+++ b/src/mocks/learn.mock.ts
@@ -1,5 +1,5 @@
 import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
-import { LearnProgressResponse } from '@/domains/course/types/progress';
+import { GetLearnLectureProgressResponse } from '@/domains/course/types/progress';
 
 export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
   '2002': {
@@ -104,7 +104,7 @@ export const MOCK_LEARN_ENROLLMENT: LearnEnrollmentResponse = {
   expiredAt: '2026-01-01T09:00:00',
 };
 
-export const MOCK_LEARN_PROGRESS: LearnProgressResponse = {
+export const MOCK_LEARN_PROGRESS: GetLearnLectureProgressResponse = {
   enrollmentId: '5001',
   progressRate: 5,
 

--- a/src/mocks/learn.mock.ts
+++ b/src/mocks/learn.mock.ts
@@ -1,12 +1,8 @@
-import type {
-  LearnCourseResponse,
-  LearnEnrollmentResponse,
-  LearnProgressResponse,
-} from '@/domains/course/types/learn';
+import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
 
 export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
-  '2001': {
-    courseId: '2001',
+  '2002': {
+    courseId: '2002',
     title: '스프링 부트 완벽 가이드',
     summary: '스프링 부트의 모든 것',
     description: '기초부터 실전까지',
@@ -27,31 +23,31 @@ export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
 
     sections: [
       {
-        sectionId: '3001',
+        sectionId: 's1',
         title: '1. JPA 시작하기',
         order: 1,
         lectures: [
           {
-            lectureId: '4001',
+            lectureId: '3001',
             title: 'JPA란?',
             totalDurationSeconds: 10,
             isPreview: false,
             orderIndex: 1,
             resource: {
-              resourceId: '5001',
+              resourceId: '3001',
               resourceType: 'VIDEO',
               fileUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
               isDownloadable: false,
             },
           },
           {
-            lectureId: '4002',
+            lectureId: '3002',
             title: '엔티티 매핑',
             totalDurationSeconds: 10,
             isPreview: false,
             orderIndex: 2,
             resource: {
-              resourceId: '5002',
+              resourceId: '3002',
               resourceType: 'VIDEO',
               fileUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
               isDownloadable: false,
@@ -60,31 +56,31 @@ export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
         ],
       },
       {
-        sectionId: '3002',
+        sectionId: 's2',
         title: '2. 연관관계',
         order: 2,
         lectures: [
           {
-            lectureId: '4003',
+            lectureId: '3003',
             title: '연관관계 기본',
             totalDurationSeconds: 10,
             isPreview: false,
-            orderIndex: 1,
+            orderIndex: 3,
             resource: {
-              resourceId: '5003',
+              resourceId: '3003',
               resourceType: 'VIDEO',
               fileUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
               isDownloadable: false,
             },
           },
           {
-            lectureId: '4004',
+            lectureId: '3004',
             title: '양방향 매핑',
             totalDurationSeconds: 10,
             isPreview: false,
-            orderIndex: 2,
+            orderIndex: 4,
             resource: {
-              resourceId: '5004',
+              resourceId: '3004',
               resourceType: 'VIDEO',
               fileUrl: 'https://www.w3schools.com/html/mov_bbb.mp4',
               isDownloadable: false,
@@ -98,52 +94,57 @@ export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
 
 export const MOCK_LEARN_ENROLLMENT: LearnEnrollmentResponse = {
   enrollmentId: '5001',
-  userId: 'u-001',
-  courseId: '2001',
-  studentId: 'u-001',
+  userId: 'user_001',
+  courseId: '2002',
+  studentId: 'user_001',
   status: 'ENROLLED',
-  progressRate: 45,
+  progressRate: 0,
   createdAt: '2025-12-02T09:00:00',
   expiredAt: '2026-01-01T09:00:00',
 };
 
 export const MOCK_LEARN_PROGRESS = {
   enrollmentId: '5001',
-  progressRate: 25,
+  progressRate: 5,
 
   lastVideoId: '3001',
-  lastWatchedDuration: 120,
+  lastWatchedDuration: 5,
   lastWatchedAt: '2025-12-02T09:30:00',
 
   lectureProgresses: [
     {
       resourceId: '3001',
-      title: '강의 1',
-      currentProgressRate: 100,
-      watchedDuration: 240,
-      totalDurationSeconds: 240,
-      isCompleted: true,
+      currentProgressRate: 50,
+      watchedDuration: 5,
+      totalDurationSeconds: 10,
+      isCompleted: false,
       lastWatchedAt: '2025-12-02T09:30:00',
     },
     {
       resourceId: '3002',
-      title: '강의 2',
       currentProgressRate: 0,
       watchedDuration: 0,
-      totalDurationSeconds: 300,
+      totalDurationSeconds: 10,
+      isCompleted: false,
+      lastWatchedAt: '2025-12-02T09:40:00',
+    },
+    {
+      resourceId: '3003',
+      currentProgressRate: 0,
+      watchedDuration: 0,
+      totalDurationSeconds: 10,
+      isCompleted: false,
+      lastWatchedAt: null,
+    },
+    {
+      resourceId: '3004',
+      currentProgressRate: 0,
+      watchedDuration: 0,
+      totalDurationSeconds: 10,
       isCompleted: false,
       lastWatchedAt: null,
     },
   ],
 
   updatedAt: '2025-12-02T09:30:00',
-};
-
-export let mockLearnProgress = {
-  enrollmentId: 'mock-enrollment-1',
-  lastVideoId: null,
-  lastWatchedDuration: 0,
-  completedLectureIds: [] as string[],
-  progressRate: 0,
-  updatedAt: new Date().toISOString(),
 };

--- a/src/mocks/learn.mock.ts
+++ b/src/mocks/learn.mock.ts
@@ -1,5 +1,5 @@
 import type { LearnCourseResponse, LearnEnrollmentResponse } from '@/domains/course/types/learn';
-import { GetLearnLectureProgressResponse } from '@/domains/course/types/progress';
+import { GetLearnProgressResponse } from '@/domains/course/types/progress';
 
 export const MOCK_LEARN_COURSE_MAP: Record<string, LearnCourseResponse> = {
   '2002': {
@@ -104,7 +104,7 @@ export const MOCK_LEARN_ENROLLMENT: LearnEnrollmentResponse = {
   expiredAt: '2026-01-01T09:00:00',
 };
 
-export const MOCK_LEARN_PROGRESS: GetLearnLectureProgressResponse = {
+export const MOCK_LEARN_PROGRESS: GetLearnProgressResponse = {
   enrollmentId: '5001',
   progressRate: 5,
 

--- a/src/shared/guards/RequireLearn.ts
+++ b/src/shared/guards/RequireLearn.ts
@@ -19,7 +19,7 @@ export async function requireLearn(courseId: string): Promise<GuardLearnResult> 
   // TODO: 임시 목업 데이터
   // const enrollment = await getEnrollmentByCourseId(courseId);
   const enrollment = MOCK_ENROLLMENT_LIST.content.find(
-    (e) => e.userId === user.userId && e.courseId === courseId,
+    (e) => e.userId === user.id && e.courseId === courseId,
   );
 
   if (!enrollment) {


### PR DESCRIPTION
## 변경 사항
- 강의 학습 페이지 **이어보기(Resume)** 기능 구현
- 영상 재생 중 / 종료 시 학습 진도 저장 로직 추가
- 마지막 학습 강의 및 시점을 기준으로 자동 시작 강의 결정
- 영상 종료 시 다음 강의로 자동 이동 처리
- 강의 완료 여부에 따른 커리큘럼 체크 아이콘 표시
- 마이페이지 수강 강좌 목록에서
  - 진행 이력이 있으면 `이어보기`
  - 없으면 `처음부터` 버튼 분기 처리
- mock 데이터 기반으로 전체 학습 흐름 검증

## 리뷰 필요
- [시나리오](https://www.notion.so/ohgiraffers/mock-2e7649136c1180d380f1e093c3857e2b?source=copy_link) 보고 동작테스트 확인 부탁드려요.
  - `useCourseLearnProgress` 훅에서의 진도 관리 로직 구조가 적절한지
  - `resumeInfo` 기준으로 시작 강의를 결정하는 로직이 명확한지
  - `mapCourse`에서 UI 모델로 변환하는 책임 분리가 괜찮은지
  - 영상 종료 → 완료 처리 → 다음 강의 이동 흐름이 자연스러운지

close #117
