### PR TITLE
feat: 유저 전역 상태에 장바구니 상태 통합 및 데이터 소스 단일화

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,9 @@ import './index.css';
 import { cookies } from 'next/headers';
 import { getUserProfile } from '@/domains/user/services/userService';
 import { User } from '@/domains/user/types/user';
+import { getCart } from '@/domains/cart/services/cartService';
+import { MOCK_GET_CART } from '@/mocks/cart.mock';
+import { USE_MOCK } from '@/shared/constants/config';
 import { MSWProvider } from './_providers/msw-provider';
 import { AuthProvider } from './_providers/AuthProvider';
 
@@ -15,35 +18,6 @@ export const metadata: Metadata = {
   title: 'Lernix',
   description: '역할 전환형 온라인 학습 플랫폼',
 };
-
-async function fetchInitialUser(): Promise<User | null> {
-  const cookieStore = await cookies();
-  const accessToken = cookieStore.get('accessToken')?.value;
-
-  if (!accessToken) return null;
-
-  try {
-    const userProfile = await getUserProfile();
-
-    if (!userProfile) return null;
-
-    const user: User = {
-      id: userProfile.id,
-      email: userProfile.email,
-      nickname: userProfile.nickname,
-      roles: userProfile.roles,
-      cart: [],
-      enrolledCourses: [],
-      createdCourses: [],
-      createdAt: new Date(userProfile.createdAt),
-    };
-
-    return user;
-  } catch (err) {
-    // 만료/401은 정상 케이스
-    return null;
-  }
-}
 
 export default async function RootLayout({ children }: { children: React.ReactNode }) {
   const initialUser = await fetchInitialUser();
@@ -61,4 +35,49 @@ export default async function RootLayout({ children }: { children: React.ReactNo
       </body>
     </html>
   );
+}
+
+async function fetchInitialCart(): Promise<string[]> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+  if (!accessToken) return [];
+
+  try {
+    // TODO: API 정상화 후 제거 또는 MSW로 전환
+    const cart = USE_MOCK ? MOCK_GET_CART : await getCart();
+    const items = cart?.items ?? [];
+    return items.map((it) => String(it.courseId));
+  } catch {
+    return [];
+  }
+}
+
+async function fetchInitialUser(): Promise<User | null> {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  if (!accessToken) return null;
+
+  try {
+    const userProfile = await getUserProfile();
+    if (!userProfile) return null;
+
+    const cartCourseIds = await fetchInitialCart().catch(() => []);
+
+    const user: User = {
+      id: userProfile.id,
+      email: userProfile.email,
+      nickname: userProfile.nickname,
+      roles: userProfile.roles,
+      cart: cartCourseIds,
+      enrolledCourses: [],
+      createdCourses: [],
+      createdAt: new Date(userProfile.createdAt),
+    };
+
+    return user;
+  } catch {
+    // 만료/401은 정상 케이스
+    return null;
+  }
 }

--- a/src/domains/cart/pages/CartClientPage.tsx
+++ b/src/domains/cart/pages/CartClientPage.tsx
@@ -12,13 +12,15 @@ import {
   getCart,
   preparePayment,
 } from '@/domains/cart/services/cartService';
-
 import styles from '@/app/cart/CartPage.module.css';
 import { MOCK_GET_CART } from '@/mocks/cart.mock';
 import { MOCK_GET_COURSE_DETAIL } from '@/mocks/course.mock';
+import { USE_MOCK } from '@/shared/constants/config';
+import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import type { CartItemResponse, PreparePaymentResponse } from '../types/cart';
 import { useTossPayment } from '../hooks/useTossPayment';
-import { USE_MOCK } from '@/shared/constants/config';
+
+const normalize = (arr: string[]) => arr.slice().sort().join('|');
 
 export function CartClientPage() {
   const searchParams = useSearchParams();
@@ -32,6 +34,29 @@ export function CartClientPage() {
   const [cartMutating, setCartMutating] = useState(false);
 
   const handledInitialCourseIdRef = useRef<string | null>(null);
+
+  const { user, setUser } = useAuthState();
+  const cartInitializedRef = useRef(false);
+
+  const syncUserCartFromItems = (nextItems: CartItemType[]) => {
+    const currentUser = user;
+    if (!currentUser) return;
+
+    const nextCourseIds = Array.from(new Set(nextItems.map((it) => String(it.id))));
+    const prev = currentUser.cart ?? [];
+
+    if (normalize(prev) === normalize(nextCourseIds)) return;
+
+    setUser({
+      ...currentUser,
+      cart: nextCourseIds,
+    });
+  };
+
+  useEffect(() => {
+    if (!cartInitializedRef.current) return;
+    syncUserCartFromItems(items);
+  }, [items]);
 
   const selectedItems = useMemo(
     () => items.filter((item) => selectedMap[String(item.id)]),
@@ -54,6 +79,8 @@ export function CartClientPage() {
       const { items: details } = await getCart();
       const mappedItems = mapCartDetailsToItems(details);
 
+      cartInitializedRef.current = true;
+
       setItems(mappedItems);
 
       if (opts?.selectOnlyCourseId) {
@@ -72,6 +99,9 @@ export function CartClientPage() {
     // TODO: API 정상화 후 제거 또는 MSW로 전환
     if (USE_MOCK) {
       const base = mapCartDetailsToItems(MOCK_GET_CART.items);
+
+      cartInitializedRef.current = true;
+
       setItems((prev) => {
         const byId = new Map(prev.map((it) => [String(it.id), it]));
         base.forEach((it) => byId.set(String(it.id), it));
@@ -129,7 +159,6 @@ export function CartClientPage() {
         }
 
         await addCartItem({ courseId: Number(initialCourseId) });
-
         await refetchCart({ selectOnlyCourseId: initialCourseId });
       } catch (e) {
         console.error('장바구니 담기(추가) 처리에 실패했습니다.', e);

--- a/src/domains/course/pages/CourseDetailClientPage.tsx
+++ b/src/domains/course/pages/CourseDetailClientPage.tsx
@@ -6,7 +6,6 @@ import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { useModal } from '@/shared/hooks/useModal';
 import { LoginModal } from '@/domains/auth/components/LoginModal';
-import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import { CourseApplyModal } from '@/domains/course/components/CourseApplyModal';
 import { FloatingCTA } from '@/domains/course/components/FloatingCTA';
 import { useCourseApply } from '@/domains/course/hooks/useCourseApply';
@@ -15,6 +14,8 @@ import { formatDuration } from '@/domains/course/utils/formatDuration';
 import styles from '@/app/courses/[id]/CourseDetailPage.module.css';
 import { MOCK_GET_CART } from '@/mocks/cart.mock';
 import { addCartItem } from '@/domains/cart/services/cartService';
+import { useAuthState } from '@/domains/auth/hooks/useAuthState';
+import { USE_MOCK } from '@/shared/constants/config';
 import type { Section, Lecture } from '../types/course';
 import { LEVEL_LABEL } from '../constants/level';
 import { formatAbsoluteUrl } from '../utils/formatAbsoluteUrl';
@@ -23,8 +24,6 @@ import CourseReviewModal from '../components/CourseReviewModal';
 import { useCourseReviews } from '../hooks/useCourseReview';
 import { StarRating } from '../components/StarRating';
 import { formatReviewDate } from '../utils/formatReviewDate';
-
-const USE_MOCK = process.env.NEXT_PUBLIC_USE_MOCK;
 
 type TabKey = 'intro' | 'curriculum' | 'reviews';
 
@@ -67,10 +66,7 @@ export default function CourseDetailClientPage() {
     return Math.round((sum / reviewCount) * 10) / 10; // 소수점 1자리
   }, [reviews, reviewCount]);
 
-  // TODO: API 정상화 후 제거 또는 MSW로 전환
-  const isInCart = USE_MOCK
-    ? MOCK_GET_CART.items.some((item) => String(item.courseId) === id)
-    : !!user?.cart?.includes(id);
+  const isInCart = !!user?.cart?.includes(id);
 
   const canOpenReviewModal = !user || (isEnrolled && !hasMyReview);
   const reviewButtonLabel = !user


### PR DESCRIPTION
## 변경 사항

- SSR 진입 시점에 유저 + 장바구니 초기 상태 주입
  - `RootLayout`에서 `cookies(accessToken)` 기반 `getUserProfile` 조회 후 `fetchInitialCart()` 결과를 `initialUser.cart`로 구성해 `AuthProvider`에 주입
  - `USE_MOCK` 분기에서도 동일하게 `initialUser.cart` 구성하여 첫 렌더부터 cart 일관성 확보
- /cart 변경사항을 전역 `user.cart`로 동기화
  - `/cart`에서 `items` 변경 이후 `effect`로 `user.cart = items.map(courseId)` 자동 갱신
  - `cartInitializedRef`로 초기 로딩 이전 sync 방지
  - `syncUserCartFromItems` + `normalize` 비교로 불필요한 중복 업데이트 방지
  - mock/real 공통으로 뒤로가기 시에도 담김 상태(`user.cart.includes`) 일관되게 유지
- 강좌 상세 페이지 담김 여부 판단을 `user.cart` 기준으로 통일
  - `isInCart = user.cart.includes(courseId)`로 단일 기준 적용
  - 장바구니 담기 성공 시 `user.cart` 업데이트 유지
  - 목업/실서버 분기 제거: 담김 여부 판단을 `user.cart`로 완전 단일화


## 리뷰 필요

- 장바구니 담고 뒤로가기 시에도 Floating CTA가 `user.cart.includes` 기준으로 즉시 반영되는지 확인 부탁드립니다.


close #121
