### PR TITLE
feat: 강의 리소스 업로드 및 생성 흐름 정비

### DIFF
--- a/src/domains/course/components/ResourceUploader.tsx
+++ b/src/domains/course/components/ResourceUploader.tsx
@@ -4,16 +4,19 @@ import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import { formatDuration, formatLectureDuration } from '../utils/formatDuration';
 import { RESOURCE_CONFIG } from '../constants/resource';
 import styles from './CourseForm.module.css';
-
+import { createPresignedUploadUrl } from '../services/resourceService';
+import { bytesToKB } from '@/shared/util/fileSize';
+import { useDraftResource } from '@/domains/course/hooks/useDraftResource';
 export type ResourceType = 'VIDEO' | 'PDF' | 'DOC' | 'ZIP';
 
 export type UploadResult = {
   resourceType: ResourceType;
+  fileKey: string;
   fileUrl: string;
   previewUrl?: string;
-  isDownloadable: boolean;
-  duration?: number | null;
-  fileName?: string | undefined;
+  fileName?: string;
+  duration?: number;
+  isDownloadable?: boolean;
   multiFile?: File;
 };
 
@@ -59,6 +62,8 @@ export function ResourceUploader({
   onUploadComplete,
   onRemove,
 }: ResourceUploaderProps) {
+  const { addDraftResource } = useDraftResource();
+
   // ===== "로컬(draft)"만 state로 관리 (props->state 동기화 useEffect 제거) =====
   const [draftType, setDraftType] = useState<ResourceType | null>(null);
   const [uploading, setUploading] = useState(false);
@@ -167,20 +172,32 @@ export function ResourceUploader({
         setDraftDuration(null);
       }
 
-      // 저장용 URL (지금은 더미. 실제로는 업로드 API 응답에서 받는 게 정석)
-      const storedUrl = `/uploads/${encodeURIComponent(file.name)}`;
+      const { key } = await createPresignedUploadUrl({
+        fileName: file.name,
+        contentType: file.type,
+        size: bytesToKB(file.size),
+        duration: videoSeconds ?? 0,
+        isDownloadable: effectiveType === 'VIDEO' ? false : effectiveIsDownloadable,
+      });
 
-      setUploading(false);
+      addDraftResource({
+        resourceType: effectiveType,
+        key,
+        fileName: file.name,
+        duration: videoSeconds ?? undefined,
+        isDownloadable: effectiveType === 'VIDEO' ? false : effectiveIsDownloadable,
+      });
 
       onUploadComplete?.({
         resourceType: effectiveType,
-        fileUrl: storedUrl,
+        fileKey: key,
+        fileUrl: key,
         previewUrl: objectUrl,
-        isDownloadable: effectiveType === 'VIDEO' ? false : effectiveIsDownloadable,
         duration: videoSeconds ?? undefined,
-        fileName: file.name,
-        multiFile: file,
+        isDownloadable: effectiveType === 'VIDEO' ? false : effectiveIsDownloadable,
       });
+
+      setUploading(false);
     } catch (err) {
       let msg = '파일 처리 중 오류가 발생했습니다.';
       if (err instanceof Error) {

--- a/src/domains/course/hooks/useDraftResource.ts
+++ b/src/domains/course/hooks/useDraftResource.ts
@@ -1,0 +1,27 @@
+const DRAFT_RESOURCES_KEY = 'draftResources';
+
+export function useDraftResource() {
+  const getDraftResources = (): DraftResource[] => {
+    const raw = sessionStorage.getItem(DRAFT_RESOURCES_KEY);
+    return raw ? JSON.parse(raw) : [];
+  };
+
+  const addDraftResource = (resource: DraftResource) => {
+    const list = getDraftResources();
+    sessionStorage.setItem(DRAFT_RESOURCES_KEY, JSON.stringify([...list, resource]));
+  };
+
+  const clearDraftResources = () => {
+    sessionStorage.removeItem(DRAFT_RESOURCES_KEY);
+  };
+
+  return { getDraftResources, addDraftResource, clearDraftResources };
+}
+
+type DraftResource = {
+  resourceType: 'VIDEO' | 'PDF' | 'DOC' | 'ZIP';
+  key: string;
+  fileName: string;
+  duration?: number;
+  isDownloadable?: boolean;
+};

--- a/src/domains/course/services/lectureCreateService.ts
+++ b/src/domains/course/services/lectureCreateService.ts
@@ -1,8 +1,6 @@
 import { postApi, deleteApi, putApi } from '@/shared/lib/api/fetchApi';
 import {
   CreateLectureRequest,
-  CreateLectureResourcePresignedUrlRequest,
-  CreateLectureResourcePresignedUrlResponse,
   CreateLectureResponse,
   UpdateLectureRequest,
   UpdateLectureResponse,
@@ -23,21 +21,6 @@ export const createLecture = async (
 // 강의 삭제 API
 export async function deleteLecture(courseId: string, lectureId: string) {
   return deleteApi(`/api/instructor/courses/${courseId}/lectures/${lectureId}`);
-}
-
-// 강의 자료 업로드 presigned url 생성
-export const createLectureResourcePresignedUrl = async (
-  payload: CreateLectureResourcePresignedUrlRequest,
-): Promise<CreateLectureResourcePresignedUrlResponse> => {
-  return await postApi<CreateLectureResourcePresignedUrlResponse>(
-    `/api/instructor/resources`,
-    payload,
-  );
-};
-
-// 리소스 삭제 API
-export async function deleteLectureResource(resourceId: string) {
-  return deleteApi(`/api/instructor/resources/${resourceId}`);
 }
 
 // 강의 수정 API (임시강의생성수정 API)

--- a/src/domains/course/services/resourceService.ts
+++ b/src/domains/course/services/resourceService.ts
@@ -1,0 +1,22 @@
+import { postApi } from '@/shared/lib/api/fetchApi';
+
+export type PresignedUploadUrlRequest = {
+  fileName: string;
+  contentType: string;
+  size: number;
+  duration: number;
+  isDownloadable: boolean;
+};
+
+export type PresignedUploadUrlResponse = {
+  presignedUrl: string;
+  key: string;
+  method: 'PUT';
+  expireSeconds: number;
+};
+
+export async function createPresignedUploadUrl(
+  payload: PresignedUploadUrlRequest,
+): Promise<PresignedUploadUrlResponse> {
+  return postApi<PresignedUploadUrlResponse>('/api/instructor/resources', payload);
+}

--- a/src/domains/course/types/course.ts
+++ b/src/domains/course/types/course.ts
@@ -325,7 +325,7 @@ export type UpdateSectionResponse = {
 };
 
 // ===== API: Presigned URL 생성 =====
-export type CreateLectureResourcePresignedUrlRequest = {
+export type PresignedUploadUrlRequest = {
   fileName: string;
   contentType: string;
   size: number;
@@ -333,17 +333,11 @@ export type CreateLectureResourcePresignedUrlRequest = {
   isDownloadable: boolean;
 };
 
-export type CreateLectureResourcePresignedUrlResponse = {
+export type PresignedUrlResponse = {
   presignedUrl: string;
   key: string;
-  method: 'PUT' | 'GET';
-  expireSeconds: number;
-};
-
-// 썸네일 업로드 url 생성 API
-export type CreateThumbnailPresignedUrlResponse = {
-  presignedUrl: string;
-  key: string;
+  method?: 'PUT' | 'GET';
+  expireSeconds?: number;
 };
 
 export type DeleteSectionRequest = {};

--- a/src/shared/services/uploadThumbnail.ts
+++ b/src/shared/services/uploadThumbnail.ts
@@ -1,0 +1,24 @@
+import { postApi } from '@/shared/lib/api/fetchApi';
+import type {
+  PresignedUploadUrlRequest,
+  PresignedUrlResponse,
+} from '@/domains/course/types/course';
+import { bytesToKB } from '@/shared/util/fileSize';
+
+// TODO: Thumbnail 업로드도 이 함수 사용하도록 리팩토링 필요
+export async function uploadThumbnail(file: File): Promise<string> {
+  const requestBody: PresignedUploadUrlRequest = {
+    fileName: file.name,
+    contentType: file.type,
+    size: bytesToKB(file.size),
+    duration: 0,
+    isDownloadable: true,
+  };
+
+  const { presignedUrl, key } = await postApi<PresignedUrlResponse>(
+    '/api/instructor/resources',
+    requestBody,
+  );
+
+  return key;
+}

--- a/src/shared/util/fileSize.ts
+++ b/src/shared/util/fileSize.ts
@@ -1,0 +1,3 @@
+export function bytesToKB(bytes: number): number {
+  return Math.round(bytes / 1024);
+}


### PR DESCRIPTION
## 변경 사항
- 강의 리소스 업로드 결과 타입 정리
- draft 리소스 sessionStorage 관리 훅 추가
- 강의 생성/수정 시 리소스 payload 구조 통합
- 파일 사이즈 계산 및 썸네일 업로드 유틸 추가

## 리뷰 필요
- 강의 생성 / 수정 시 리소스 payload 구조가 적절한지
- draft 리소스 sessionStorage 관리 방식에 대한 의견
- 업로드 결과 타입(`UploadResult`) 필드 구성 적절성

close #130 
