### PR TITLE
feat: fetchApi 요청/응답 디버그 로깅 및 에러 핸들링 표준화

### DIFF
--- a/src/shared/lib/api/fetchApi.ts
+++ b/src/shared/lib/api/fetchApi.ts
@@ -1,7 +1,9 @@
 'use server';
 
 import { cookies } from 'next/headers';
+
 const BASE_URL = process.env.NEXT_PUBLIC_BASE_URL;
+
 export type ApiResponse<T = unknown> = {
   status: string; // HTTP 상태 코드 (예: '200', '400' 등)
   code: string; // 에러 코드 (예: EG001, EU001 등)
@@ -14,45 +16,126 @@ export type ApiResponse<T = unknown> = {
  * @param endpoint API 엔드포인트
  * @param options fetch 옵션
  */
+
+const LOG_LABELS = {
+  REQUEST_FAILED: '[fetchApi] Request failed (요청 실패)',
+  API_ERROR_CODE: '[fetchApi] API error code (서버 에러 코드)',
+  UNEXPECTED_ERROR: '[fetchApi] Unexpected error (예상치 못한 오류)',
+} as const;
+
+type LogSchema = {
+  '요청(request)': {
+    url: string;
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+  };
+  '응답(response)': {
+    status?: number;
+    statusText?: string;
+    headers?: Record<string, string>;
+    bodyRaw?: string;
+    bodyJson?: unknown;
+  };
+  '오류(error)'?: {
+    name?: string;
+    message: string;
+    stack?: string;
+    cause?: unknown;
+  };
+};
+
 export async function fetchApi<T = unknown>(
   endpoint: string,
   options: RequestInit = {},
 ): Promise<T> {
+  if (!BASE_URL) throw new Error('NEXT_PUBLIC_BASE_URL 누락');
+
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('accessToken')?.value;
+
+  const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
+
+  // 인증 헤더 설정
+  const headers = new Headers(options.headers);
+
+  if (accessToken) {
+    headers.set('Authorization', `Bearer ${accessToken}`); // 인증 토큰 포함
+  }
+
+  // JSON 요청일 때만 Content-Type 기본 부여
+  if (!isFormData) {
+    const hasContentType = headers.get('Content-Type');
+    if (!hasContentType) headers.set('Content-Type', 'application/json');
+  } else {
+    // FormData면 Content-Type을 절대 직접 넣지 않음 (boundary 자동 설정 필요)
+    headers.delete('Content-Type');
+  }
+
+  const url = endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`;
+
+  // "최종" 요청 스냅샷 (에러 시 출력용)
+  const debugInfo: FetchDebugInfo = {
+    url,
+    method: (options.method || 'GET').toUpperCase(),
+    requestHeaders: maskSensitiveHeaders(headersToObject(headers)),
+    requestBodyPreview: buildBodyPreview(options.body, isFormData),
+  };
+
+  const buildLogPayload = (extra?: LogSchema['오류(error)']): LogSchema => ({
+    '요청(request)': {
+      url: debugInfo.url,
+      method: debugInfo.method,
+      headers: debugInfo.requestHeaders,
+      body: debugInfo.requestBodyPreview,
+    },
+    '응답(response)': {
+      status: debugInfo.status,
+      statusText: debugInfo.statusText,
+      headers: debugInfo.responseHeaders,
+      bodyRaw: debugInfo.responseBodyRaw,
+      bodyJson: debugInfo.responseBodyJson,
+    },
+    ...(extra
+      ? {
+          '오류(error)': extra,
+        }
+      : {}),
+  });
+
   try {
-    if (!BASE_URL) throw new Error('NEXT_PUBLIC_BASE_URL 누락');
-
-    const cookieStore = await cookies();
-    const accessToken = cookieStore.get('accessToken')?.value;
-
-    const isFormData = typeof FormData !== 'undefined' && options.body instanceof FormData;
-
-    // 인증 헤더 설정
-    const headers = new Headers(options.headers);
-
-    if (accessToken) {
-      headers.set('Authorization', `Bearer ${accessToken}`); // 인증 토큰 포함
-    }
-
-    // JSON 요청일 때만 Content-Type 기본 부여
-    if (!isFormData) {
-      const hasContentType = headers.get('Content-Type');
-      if (!hasContentType) headers.set('Content-Type', 'application/json');
-    } else {
-      // FormData면 Content-Type을 절대 직접 넣지 않음 (boundary 자동 설정 필요)
-      headers.delete('Content-Type');
-    }
-    const url = endpoint.startsWith('http') ? endpoint : `${BASE_URL}${endpoint}`;
-
     const response = await fetch(url, {
       method: options.method || 'GET',
       ...options,
       headers,
     });
 
-    // 응답 데이터 파싱
-    const resJson = await response.json();
+    // 응답 헤더 캡쳐
+    debugInfo.status = response.status;
+    debugInfo.statusText = response.statusText;
+    debugInfo.responseHeaders = maskSensitiveHeaders(headersToObject(response.headers));
 
-    // 오류 처리
+    // 응답 바디는 "한 번만" 읽을 수 있음 - 먼저 text로 읽고, JSON이면 파싱까지 시도
+    const raw = await response.text();
+    debugInfo.responseBodyRaw = raw?.length > 8000 ? raw.slice(0, 8000) + '...(truncated)' : raw;
+
+    const contentType = response.headers.get('content-type') ?? '';
+    let resJson = null;
+
+    if (contentType.includes('application/json')) {
+      try {
+        resJson = raw ? JSON.parse(raw) : null;
+        debugInfo.responseBodyJson = resJson;
+      } catch (e) {
+        // JSON인데 파싱 실패한 경우도 로그에 남기기
+        debugInfo.responseBodyJson = { parseError: String(e) };
+      }
+    } else {
+      // JSON이 아니면 raw만 남기고, 최소한의 형태만 맞춰둠
+      resJson = { code: 'E_NON_JSON', message: raw };
+    }
+
+    // HTTP 에러
     if (!response.ok) {
       // 만약 응답이 401 (리프레시 토큰 만료)일 경우 -> 재로그인
       if (response.status === 401) {
@@ -61,7 +144,13 @@ export async function fetchApi<T = unknown>(
         console.error('리프레시 토큰이 만료되었습니다. 다시 로그인이 필요합니다.');
       }
 
-      throw new Error(`[${response.status} (${resJson.code}) - ${resJson.message}]`);
+      // 요청/응답 전체 로그
+      console.error(LOG_LABELS.REQUEST_FAILED, buildLogPayload());
+
+      const code = (resJson && resJson.code) || 'NO_CODE';
+      const message = (resJson && resJson.message) || response.statusText || 'Unknown';
+
+      throw new FetchApiError(`[${response.status} (${code}) - ${message}]`, debugInfo);
     }
 
     // 응답 헤더에 새로운 액세스 토큰이 있다면 쿠키 갱신
@@ -72,15 +161,43 @@ export async function fetchApi<T = unknown>(
       });
     }
 
-    // 에러 코드 처리
-    if (resJson.code.startsWith('E')) {
-      throw new Error(resJson.message);
+    // 규격 에러 코드(E*) 처리
+    if (typeof resJson?.code === 'string' && resJson.code.startsWith('E')) {
+      // 규격 에러 출력
+      console.error(
+        LOG_LABELS.API_ERROR_CODE,
+        buildLogPayload({
+          name: 'ApiErrorCode',
+          message: resJson.message ?? '서버 에러 코드(E*)가 반환되었습니다.',
+        }),
+      );
+      throw new FetchApiError(resJson.message, debugInfo);
     }
 
-    return resJson.data as T;
+    return (resJson?.data ?? resJson) as T;
   } catch (error: unknown) {
-    if (error instanceof Error) throw new Error(error.message);
-    throw new Error('알 수 없는 오류가 발생했습니다.');
+    // 이미 FetchApiError면 중복 로그 줄이기 (원하면 다시 찍어도 됨)
+    if (error instanceof FetchApiError) throw error;
+
+    // 예상치 못한 오류 출력
+    const errObj =
+      error instanceof Error
+        ? {
+            name: error.name,
+            message: error.message,
+            stack: error.stack,
+            cause: error.cause,
+          }
+        : {
+            message: String(error),
+          };
+
+    console.error(LOG_LABELS.UNEXPECTED_ERROR, buildLogPayload(errObj));
+
+    if (error instanceof Error) {
+      throw new FetchApiError(error.message, debugInfo, error);
+    }
+    throw new FetchApiError('알 수 없는 오류가 발생했습니다.', debugInfo, error);
   }
 }
 
@@ -158,4 +275,71 @@ export async function patchApi<T = unknown>(
     body: JSON.stringify(data),
     ...options,
   });
+}
+
+type FetchDebugInfo = {
+  url: string;
+  method: string;
+  requestHeaders: Record<string, string>;
+  requestBodyPreview?: string;
+  status?: number;
+  statusText?: string;
+  responseHeaders?: Record<string, string>;
+  responseBodyRaw?: string; // 원문(텍스트)
+  responseBodyJson?: unknown; // JSON 파싱 결과
+};
+
+function headersToObject(headers: Headers): Record<string, string> {
+  return Object.fromEntries(headers.entries());
+}
+
+function maskSensitiveHeaders(headers: Record<string, string>) {
+  const masked = { ...headers };
+
+  const mask = (v?: string | null) => (v ? v.replace(/^(.{0,8}).+$/, '$1***') : (v ?? ''));
+
+  // 요청/응답에서 흔히 민감한 것들 마스킹
+  if (masked.Authorization) masked.Authorization = mask(masked.Authorization);
+  if (masked.authorization) masked.authorization = mask(masked.authorization);
+
+  if (masked.Cookie) masked.Cookie = '***';
+  if (masked.cookie) masked.cookie = '***';
+
+  if (masked['Set-Cookie']) masked['Set-Cookie'] = '***';
+  if (masked['set-cookie']) masked['set-cookie'] = '***';
+
+  return masked;
+}
+
+function buildBodyPreview(body: RequestInit['body'], isFormData: boolean): string | undefined {
+  if (!body) return undefined;
+
+  // FormData는 그대로 stringify 불가 → 어떤 키가 있는지만 보여주기
+  if (isFormData && body instanceof FormData) {
+    const keys = Array.from(body.keys());
+    return `FormData(keys=${JSON.stringify(keys)})`;
+  }
+
+  if (typeof body === 'string') {
+    return body.length > 2000 ? body.slice(0, 2000) + '...(truncated)' : body;
+  }
+
+  // ArrayBuffer/Blob/Stream 등은 미리보기 제한
+  if (body instanceof ArrayBuffer) return `ArrayBuffer(byteLength=${body.byteLength})`;
+  if (typeof Blob !== 'undefined' && body instanceof Blob)
+    return `Blob(size=${body.size}, type=${body.type})`;
+
+  // ReadableStream 등은 안전하게 타입만
+  return `Body(type=${Object.prototype.toString.call(body)})`;
+}
+
+class FetchApiError extends Error {
+  debug: FetchDebugInfo;
+
+  constructor(message: string, debug: FetchDebugInfo, cause?: unknown) {
+    // TS/JS 런타임 지원 시 cause 붙여줌
+    super(message, { cause });
+    this.name = 'FetchApiError';
+    this.debug = debug;
+  }
 }


### PR DESCRIPTION
## 변경 사항

- fetchApi 에러 로그 라벨 3종 (Request failed / API error code / Unexpected error) 통일
- 요청(request) / 응답(response) / 오류(error) 구조로 로그 스키마 표준화
- 응답 바디를 raw/json으로 분리 저장하여 비JSON 에러/게이트웨이 응답도 확인 가능
- 민감 헤더(Authorization/Cookie/Set-Cookie) 마스킹 처리 유지 및 보완
- FetchApiError에 debugInfo를 포함해 상위 레이어에서도 디버그 정보 확인 가능

## 리뷰 필요

- 터미널 로그 출력 포맷(라벨/스키마/키 네이밍)이 팀 기준에 적절한지 확인 부탁드립니다.
- 운영 환경 로그 정책(DEV에서만 출력 / env flag 기반 제어 / 현재처럼 항상 출력) 방향성 논의가 필요합니다.

close #135
