### PR TITLE
feat: 강좌 시청 페이지에서 강좌 상세로 이동 링크 추가

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,9 +11,9 @@ const nextConfig: NextConfig = {
       },
       {
         protocol: 'http',
-        hostname: '3.34.122.45',
-        port: '8080',
-        pathname: '/uploads/**',
+        hostname: 'localhost',
+        port: '8081',
+        pathname: '/images/**',
       },
       {
         protocol: 'https',

--- a/src/app/courses/[id]/learn/CourseLearnPage.module.css
+++ b/src/app/courses/[id]/learn/CourseLearnPage.module.css
@@ -25,6 +25,12 @@
   gap: 6px;
 }
 
+.course-learn__header-right {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
 .course-learn__back-btn {
   background: transparent;
   border: 1px solid var(--color-border);
@@ -61,6 +67,28 @@
 .course-learn__progress {
   font-size: var(--text-sm);
   color: var(--muted);
+}
+
+.course-learn__detail-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  border-radius: 8px;
+  border: 1px solid var(--color-border);
+  color: var(--color-text);
+  text-decoration: none;
+  font-size: var(--text-xs);
+  font-weight: 600;
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
+}
+
+.course-learn__detail-button:hover,
+.course-learn__detail-button:focus-visible {
+  color: var(--color-brand);
+  border-color: var(--color-brand);
 }
 
 .course-learn__layout {

--- a/src/app/courses/[id]/learn/CourseLearnPage.module.css
+++ b/src/app/courses/[id]/learn/CourseLearnPage.module.css
@@ -27,16 +27,29 @@
 
 .course-learn__back-btn {
   background: transparent;
-  border: none;
-  padding: 6px 0;
-  border-radius: 6px;
+  border: 1px solid var(--color-border);
+  padding: 6px 8px;
+  border-radius: 8px;
   cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-text-muted);
+  transition:
+    border-color 0.2s ease,
+    color 0.2s ease;
 }
 
 .course-learn__icon {
   width: 20px;
   height: 20px;
-  color: var(--color-text-muted);
+  color: currentColor;
+}
+
+.course-learn__back-btn:hover,
+.course-learn__back-btn:focus-visible {
+  border-color: var(--color-brand);
+  color: var(--color-brand);
 }
 
 .course-learn__title {

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -10,6 +10,7 @@ import {
   CheckCircle,
 } from 'lucide-react';
 import { useRef, useEffect, useMemo } from 'react';
+import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCourseLearn } from '@/domains/course/hooks/useCourseLearn';
 import { useProgress } from '@/domains/course/hooks/useProgress';
@@ -102,8 +103,16 @@ export default function CourseLearnClient({ enrollmentId }: CourseLearnClientPro
             </button>
             <h1 className={styles['course-learn__title']}>{courseData.title}</h1>
           </div>
-          <div className={styles['course-learn__progress']}>
-            진도율: {completedLectures}/{totalLectures} 완료
+          <div className={styles['course-learn__header-right']}>
+            <div className={styles['course-learn__progress']}>
+              진도율: {completedLectures}/{totalLectures} 완료
+            </div>
+            <Link
+              className={styles['course-learn__detail-button']}
+              href={`/courses/${courseData.courseId}`}
+            >
+              강좌 상세 보기
+            </Link>
           </div>
         </div>
       </header>


### PR DESCRIPTION
## 변경 사항

- 강좌 시청 페이지 뒤로가기 버튼 스타일 개선
- 강좌 시청 페이지에 강좌 상세보기 버튼 추가
- next.config.ts에 이미지 remotePatterns 설정 추가

close #139 
