### PR TITLE
feat: 썸네일 fallback 이미지 임시 처리

### DIFF
--- a/src/domains/cart/components/CartItem.tsx
+++ b/src/domains/cart/components/CartItem.tsx
@@ -44,7 +44,7 @@ export const CartItem: React.FC<Props> = ({ item, checked = false, onSelectChang
       <div className={styles['cart-item__thumb']}>
         <Image
           // TODO: 썸네일 임시 처리 - formatAbsoluteUrl(course.thumbnailUrl)
-          src={'/course-thumbnail-fallback.png'}
+          src={'/default-thumbnail.png'}
           alt={`${item.title} 썸네일`}
           width={160}
           height={90}

--- a/src/domains/course/pages/CourseDetailClientPage.tsx
+++ b/src/domains/course/pages/CourseDetailClientPage.tsx
@@ -157,7 +157,7 @@ export default function CourseDetailClientPage() {
           height={450}
           className={styles['course-detail__hero']}
           // TODO: 썸네일 임시 처리 - formatAbsoluteUrl(course.thumbnailUrl)
-          src={'/course-thumbnail-fallback.png'}
+          src={'/default-thumbnail.png'}
           alt={`${course.title} 썸네일`}
           loading="lazy"
         />

--- a/src/domains/course/pages/CourseListClientPage.tsx
+++ b/src/domains/course/pages/CourseListClientPage.tsx
@@ -26,7 +26,7 @@ export default function CourseListClientPage() {
           id: item.courseId,
           title: item.title,
           summary: item.summary,
-          thumbnailUrl: item.thumbnailUrl ?? '/images/default-thumbnail.png',
+          thumbnailUrl: item.thumbnailUrl ?? '/default-thumbnail.png',
           instructorName: item.instructorName,
           category: item.categories,
           level: item.level,


### PR DESCRIPTION
## 변경 사항
- 강좌/장바구니/상세 페이지에서 썸네일이 없는 경우를 대비해 fallback 이미지 적용
- Next.js public 경로 규칙에 맞게 썸네일 경로 정리
- 사용되지 않는 public SVG 리소스(file, globe, next, vercel, window) 제거

## 리뷰 필요
- 썸네일 fallback 처리 방식이 적절한지 확인 부탁드립니다
- example.com 도메인 필터링 조건을 추후 제거하는 방향에 대한 의견 요청

close #144 
