### PR TITLE
refactor: 수강 목록에서 학습 시작 분기 제거

### DIFF
--- a/src/domains/user/pages/EnrollmentClientPage.tsx
+++ b/src/domains/user/pages/EnrollmentClientPage.tsx
@@ -136,13 +136,6 @@ export default function EnrollmentClientPage() {
 
       <div className={styles['enrollment-section__list']}>
         {items.map((item) => {
-          const hasProgress = (item.progressRate ?? 0) > 0;
-
-          const buttonLabel = hasProgress ? '이어보기' : '처음부터';
-          const buttonHref = hasProgress
-            ? `/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}`
-            : `/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}&start=first`;
-
           return (
             <div key={item.enrollmentId} className={styles['enrollment-card']}>
               <div className={styles['enrollment__link']}>
@@ -170,15 +163,13 @@ export default function EnrollmentClientPage() {
                   >
                     {item.isReviewed ? '리뷰 수정' : '리뷰 작성'}
                   </button>
-                  {hasProgress && (
-                    <Link
-                      href={buttonHref}
-                      className={styles['btn-primary']}
-                      aria-label={buttonLabel}
-                    >
-                      <Play />
-                    </Link>
-                  )}
+                  <Link
+                    href={`/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}`}
+                    className={styles['btn-primary']}
+                    aria-label="학습하기"
+                  >
+                    <Play />
+                  </Link>
                 </div>
               </div>
 


### PR DESCRIPTION
## 변경 사항
- 수강 목록 페이지에서 progressRate 기반 학습 시작 분기 로직 제거
- Learn 페이지 진입 시 enrollmentId만 전달하도록 단순화
- 학습 시작 지점 판단 책임을 Learn 페이지로 분리

## 리뷰 필요
- 수강 목록 페이지에서 학습 시작 분기를 제거한 설계 방향이 적절한지
- Learn 페이지에서 이어보기 판단 로직과의 역할 분리가 자연스러운지

close #150 