### PR TITLE
fix: 리뷰 단건 조회 연동 및 마이페이지 리뷰 목록 호출 제거

### DIFF
--- a/src/domains/course/hooks/useCourseReview.tsx
+++ b/src/domains/course/hooks/useCourseReview.tsx
@@ -14,17 +14,24 @@ import {
   createReview as createReviewApi,
   deleteReview as deleteReviewApi,
   getAllReviews,
+  getMyReview,
   updateReview as updateReviewApi,
 } from '../services/reviewService';
 
 type MyReviewStatus = { status: 'none' } | { status: 'exists'; reviewId: string };
 
-export function useCourseReviews(courseId: string) {
+type UseCourseReviewsOptions = {
+  fetchAll?: boolean;
+};
+
+export function useCourseReviews(courseId: string, options?: UseCourseReviewsOptions) {
   const [reviews, setReviews] = useState<Review[]>([]);
+  const [myReviewState, setMyReviewState] = useState<Review | null>(null);
   const { user } = useAuthState();
+  const shouldFetchAll = options?.fetchAll ?? true;
 
   useEffect(() => {
-    if (!courseId) return;
+    if (!courseId || !shouldFetchAll) return;
 
     (async () => {
       try {
@@ -32,19 +39,9 @@ export function useCourseReviews(courseId: string) {
           ? (MOCK_GET_COURSE_REVIEWS[courseId] ?? [])
           : await getAllReviews(courseId);
 
-        const mapped: Review[] = (items ?? []).map((it: GetReviewResponse) => {
-          return {
-            id: String(it.id),
-            courseId: String(it.courseId ?? courseId),
-            nickname: String(it.nickname ?? ''),
-            rating: Number(it.rating ?? 0),
-            content: String(it.content ?? ''),
-            createdAt: String(it.createdAt ?? ''),
-            updatedAt: String(it.updatedAt ?? ''),
-            isMine: Boolean(it.isMine),
-            status: it.status,
-          };
-        });
+        const mapped: Review[] = (items ?? []).map((it: GetReviewResponse) =>
+          mapReview(it, courseId),
+        );
 
         setReviews(mapped);
       } catch (e) {
@@ -54,7 +51,43 @@ export function useCourseReviews(courseId: string) {
     })();
   }, [courseId]);
 
-  const myReview = useMemo(() => reviews.find((r) => r.isMine), [reviews]);
+  useEffect(() => {
+    if (USE_MOCK) return;
+    if (!courseId || !user) return;
+
+    let cancelled = false;
+    (async () => {
+      try {
+        const review = await getMyReview(courseId);
+        if (cancelled) return;
+        setMyReviewState(mapReview(review, courseId, true));
+      } catch (e) {
+        if (cancelled) return;
+        setMyReviewState(null);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [courseId, user]);
+
+  const myReview = useMemo(() => {
+    if (!courseId || !user) return null;
+
+    if (USE_MOCK) {
+      if (shouldFetchAll) {
+        return reviews.find((r) => r.isMine) ?? null;
+      }
+      const list = MOCK_GET_COURSE_REVIEWS[courseId] ?? [];
+      const mine = list.find((r) => Boolean(r.isMine));
+      return mine ? mapReview(mine, courseId, true) : null;
+    }
+
+    if (!myReviewState) return null;
+    if (String(myReviewState.courseId) !== String(courseId)) return null;
+    return myReviewState;
+  }, [courseId, user, reviews, shouldFetchAll, myReviewState]);
 
   const myReviewStatus: MyReviewStatus = useMemo(() => {
     if (!myReview) return { status: 'none' };
@@ -79,21 +112,20 @@ export function useCourseReviews(courseId: string) {
       const now = new Date().toISOString();
 
       // mock / real 공통: UI 즉시 반영
-      setReviews((prev) => {
-        const newReview: Review = {
-          id: globalThis.crypto?.randomUUID?.() ?? `rev_${Date.now()}`,
-          courseId,
-          nickname: user.nickname,
-          rating: payload.rating ?? 0,
-          content: payload.content?.trim() ?? '',
-          createdAt: now,
-          updatedAt: now,
-          isMine: true,
-          status: 'DISPLAY',
-        };
+      const newReview: Review = {
+        id: globalThis.crypto?.randomUUID?.() ?? `rev_${Date.now()}`,
+        courseId,
+        nickname: user.nickname,
+        rating: payload.rating ?? 0,
+        content: payload.content?.trim() ?? '',
+        createdAt: now,
+        updatedAt: now,
+        isMine: true,
+        status: 'DISPLAY',
+      };
 
-        return [newReview, ...prev.map((r) => ({ ...r, isMine: false }))];
-      });
+      setMyReviewState(newReview);
+      setReviews((prev) => [newReview, ...prev.map((r) => ({ ...r, isMine: false }))]);
     },
     [courseId, user],
   );
@@ -105,6 +137,16 @@ export function useCourseReviews(courseId: string) {
 
       if (USE_MOCK) {
         const now = new Date().toISOString();
+        const nextReview = myReviewState
+          ? {
+              ...myReviewState,
+              rating: payload.rating,
+              content: payload.content.trim(),
+              updatedAt: now,
+            }
+          : null;
+
+        setMyReviewState(nextReview);
         setReviews((prev) =>
           prev.map((r) =>
             r.isMine
@@ -124,8 +166,30 @@ export function useCourseReviews(courseId: string) {
         rating: payload.rating,
         content: payload.content.trim(),
       });
+
+      const now = new Date().toISOString();
+      if (myReviewState) {
+        setMyReviewState({
+          ...myReviewState,
+          rating: payload.rating,
+          content: payload.content.trim(),
+          updatedAt: now,
+        });
+      }
+      setReviews((prev) =>
+        prev.map((r) =>
+          r.isMine
+            ? {
+                ...r,
+                rating: payload.rating,
+                content: payload.content.trim(),
+                updatedAt: now,
+              }
+            : r,
+        ),
+      );
     },
-    [courseId],
+    [courseId, myReviewState],
   );
 
   // 삭제: API가 courseId 기반이라 reviewId 필요 없음
@@ -134,10 +198,13 @@ export function useCourseReviews(courseId: string) {
 
     if (USE_MOCK) {
       setReviews((prev) => prev.filter((r) => !r.isMine));
+      setMyReviewState(null);
       return;
     }
 
     await deleteReviewApi(courseId);
+    setReviews((prev) => prev.filter((r) => !r.isMine));
+    setMyReviewState(null);
   }, [courseId]);
 
   return {
@@ -150,3 +217,17 @@ export function useCourseReviews(courseId: string) {
     removeReview,
   };
 }
+
+const mapReview = (review: GetReviewResponse, fallbackCourseId: string, isMine?: boolean): Review => {
+  return {
+    id: String(review.id),
+    courseId: String(review.courseId ?? fallbackCourseId),
+    nickname: String(review.nickname ?? ''),
+    rating: Number(review.rating ?? 0),
+    content: String(review.content ?? ''),
+    createdAt: String(review.createdAt ?? ''),
+    updatedAt: String(review.updatedAt ?? ''),
+    isMine: isMine ?? Boolean(review.isMine),
+    status: review.status,
+  };
+};

--- a/src/domains/course/pages/CourseDetailClientPage.tsx
+++ b/src/domains/course/pages/CourseDetailClientPage.tsx
@@ -54,10 +54,9 @@ export default function CourseDetailClientPage() {
   );
   const [isReviewOpen, setIsReviewOpen] = useState(false);
 
-  const { reviews, writeReview, editReview, removeReview, myReviewStatus } = useCourseReviews(id);
+  const { reviews, writeReview, editReview, removeReview, myReviewStatus, myReview } =
+    useCourseReviews(id);
   const reviewCount = reviews.length;
-
-  const myReview = useMemo(() => reviews.find((r) => r.isMine), [reviews]);
   const hasMyReview = myReviewStatus.status === 'exists';
 
   const avgRating = useMemo(() => {

--- a/src/domains/user/pages/EnrollmentClientPage.tsx
+++ b/src/domains/user/pages/EnrollmentClientPage.tsx
@@ -30,7 +30,7 @@ export default function EnrollmentClientPage() {
   );
 
   const { myReview, myReviewStatus, canWriteReview, writeReview, editReview } =
-    useCourseReviews(selectedCourseId);
+    useCourseReviews(selectedCourseId, { fetchAll: false });
 
   const isReviewed = myReviewStatus.status === 'exists';
 
@@ -136,7 +136,7 @@ export default function EnrollmentClientPage() {
 
       <div className={styles['enrollment-section__list']}>
         {items.map((item) => {
-          const hasProgress = (item.progressRate ?? 0) > 0;
+          const hasProgress = (item.progressRate ?? 0) >= 0;
 
           const buttonLabel = hasProgress ? '이어보기' : '처음부터';
           const buttonHref = hasProgress


### PR DESCRIPTION
## 변경 사항

- 리뷰 단건 조회 API 연동
- 마이페이지에서 리뷰 목록 호출 제거(`fetchAll` 옵션 도입/적용 범위 조정)
- 수정/삭제 후 myReview 및 리스트 동기화

close #151 
