### PR TITLE
fix: 리뷰 목록 조회 응답 타입 불일치 수정

### DIFF
--- a/src/domains/course/hooks/useCourseReview.tsx
+++ b/src/domains/course/hooks/useCourseReview.tsx
@@ -35,11 +35,9 @@ export function useCourseReviews(courseId: string, options?: UseCourseReviewsOpt
 
     (async () => {
       try {
-        const items = USE_MOCK
-          ? (MOCK_GET_COURSE_REVIEWS[courseId] ?? [])
-          : await getAllReviews(courseId);
+        const items = USE_MOCK ? MOCK_GET_COURSE_REVIEWS : ((await getAllReviews(courseId)) ?? []);
 
-        const mapped: Review[] = (items ?? []).map((it: GetReviewResponse) =>
+        const mapped: Review[] = items.content.map((it: GetReviewResponse) =>
           mapReview(it, courseId),
         );
 
@@ -79,7 +77,7 @@ export function useCourseReviews(courseId: string, options?: UseCourseReviewsOpt
       if (shouldFetchAll) {
         return reviews.find((r) => r.isMine) ?? null;
       }
-      const list = MOCK_GET_COURSE_REVIEWS[courseId] ?? [];
+      const list = MOCK_GET_COURSE_REVIEWS.content ?? [];
       const mine = list.find((r) => Boolean(r.isMine));
       return mine ? mapReview(mine, courseId, true) : null;
     }
@@ -218,7 +216,11 @@ export function useCourseReviews(courseId: string, options?: UseCourseReviewsOpt
   };
 }
 
-const mapReview = (review: GetReviewResponse, fallbackCourseId: string, isMine?: boolean): Review => {
+const mapReview = (
+  review: GetReviewResponse,
+  fallbackCourseId: string,
+  isMine?: boolean,
+): Review => {
   return {
     id: String(review.id),
     courseId: String(review.courseId ?? fallbackCourseId),

--- a/src/domains/course/types/review.ts
+++ b/src/domains/course/types/review.ts
@@ -46,7 +46,12 @@ export type GetReviewResponse = {
   isMine: boolean;
 };
 
-export type GetAllReviewsResponse = GetReviewResponse[];
+export type GetAllReviewsResponse = {
+  content: GetReviewResponse[];
+  page: number;
+  size: number;
+  hasNext: boolean;
+};
 
 export type GetIsReviewedRequest = {
   courseIds: number[];

--- a/src/domains/user/pages/EnrollmentClientPage.tsx
+++ b/src/domains/user/pages/EnrollmentClientPage.tsx
@@ -29,8 +29,10 @@ export default function EnrollmentClientPage() {
     [reviewTarget],
   );
 
-  const { myReview, myReviewStatus, canWriteReview, writeReview, editReview } =
-    useCourseReviews(selectedCourseId, { fetchAll: false });
+  const { myReview, myReviewStatus, canWriteReview, writeReview, editReview } = useCourseReviews(
+    selectedCourseId,
+    { fetchAll: false },
+  );
 
   const isReviewed = myReviewStatus.status === 'exists';
 
@@ -88,8 +90,7 @@ export default function EnrollmentClientPage() {
 
         if (USE_MOCK) {
           const merged = content.map((it) => {
-            const cid = String(it.courseId);
-            const list = MOCK_GET_COURSE_REVIEWS[cid] ?? [];
+            const list = MOCK_GET_COURSE_REVIEWS.content ?? [];
             const hasMine = list.some((r) => Boolean(r.isMine));
 
             return { ...it, isReviewed: hasMine };

--- a/src/domains/user/services/enrollmentService.ts
+++ b/src/domains/user/services/enrollmentService.ts
@@ -4,14 +4,22 @@ import type {
   EnrollmentDetailResponse,
 } from '@/domains/user/types/enrollment';
 import { LearnEnrollmentResponse } from '@/domains/course/types/learn';
+import { GetEnrollmentResponse } from '@/domains/course/types/course';
 
 // 수강 정보 조회 (강좌 ID 기준)
 export const getEnrollmentByCourseId = async (
   courseId: string,
-): Promise<LearnEnrollmentResponse> => {
-  return await getApi<LearnEnrollmentResponse>(`/api/enrollments/course/${courseId}`, {
-    cache: 'no-store',
-  });
+): Promise<GetEnrollmentResponse | null> => {
+  try {
+    return await getApi<GetEnrollmentResponse | null>(`/api/enrollments/course/${courseId}`, {
+      cache: 'no-store',
+    });
+  } catch (err) {
+    if (err instanceof Error && err.message.includes('[404 (EE004)')) {
+      return null;
+    }
+    throw err;
+  }
 };
 
 // 수강 정보 조회 (수강 ID 기준)

--- a/src/mocks/review.mock.ts
+++ b/src/mocks/review.mock.ts
@@ -1,11 +1,7 @@
-import type {
-  GetIsReviewedRequest,
-  GetIsReviewedResponse,
-  GetReviewResponse,
-} from '@/domains/course/types/review';
+import type { GetAllReviewsResponse, GetIsReviewedResponse } from '@/domains/course/types/review';
 
-export const MOCK_GET_COURSE_REVIEWS: Record<string, GetReviewResponse[]> = {
-  '2002': [
+export const MOCK_GET_COURSE_REVIEWS: GetAllReviewsResponse = {
+  content: [
     {
       id: '1',
       userId: 'user_001',
@@ -19,8 +15,6 @@ export const MOCK_GET_COURSE_REVIEWS: Record<string, GetReviewResponse[]> = {
       updatedAt: '2026-01-02T09:00:00Z',
       isMine: true,
     },
-  ],
-  '2003': [
     {
       id: '2',
       userId: 'user_001',
@@ -34,8 +28,6 @@ export const MOCK_GET_COURSE_REVIEWS: Record<string, GetReviewResponse[]> = {
       updatedAt: '2026-01-03T09:00:00Z',
       isMine: true,
     },
-  ],
-  '3001': [
     {
       id: '3',
       userId: 'user_002',
@@ -50,7 +42,9 @@ export const MOCK_GET_COURSE_REVIEWS: Record<string, GetReviewResponse[]> = {
       isMine: false,
     },
   ],
-  '2004': [],
+  page: 0,
+  size: 10,
+  hasNext: false,
 };
 
 export const MOCK_GET_IS_REVIEWED: GetIsReviewedResponse = [


### PR DESCRIPTION
## 변경 사항

- 리뷰 목록 조회 API 응답 타입 불일치 수정 (content 타입 정합성 맞춤)
- 응답 타입 변경 반영: 리뷰 목업/`useCourseReviews`/`EnrollmentClientPage` 연쇄 수정

## 리뷰 필요

- 리뷰 목록 조회 화면에서 courseId 기준으로 리뷰 노출이 정상인지 확인 부탁드립니다.
- (참고) 리뷰 목록 조회 응답에서 `isMine`이 현재 항상 `false`로 내려오고 있어, 서버 측 수정 요청 드린 상태이며 반영 대기 중입니다.

close #157
