### PR TITLE
fix: presigned URL 발급 후 PUT 업로드 단계 구현

### DIFF
--- a/src/domains/course/components/ResourceUploader.tsx
+++ b/src/domains/course/components/ResourceUploader.tsx
@@ -1,12 +1,12 @@
 'use client';
 
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
-import { formatDuration, formatLectureDuration } from '../utils/formatDuration';
-import { RESOURCE_CONFIG } from '../constants/resource';
-import styles from './CourseForm.module.css';
-import { createPresignedUploadUrl } from '../services/resourceService';
 import { bytesToKB } from '@/shared/util/fileSize';
 import { useDraftResource } from '@/domains/course/hooks/useDraftResource';
+import { formatDuration, formatLectureDuration } from '../utils/formatDuration';
+import { RESOURCE_CONFIG } from '../constants/resource';
+import { createPresignedUploadUrl } from '../services/resourceService';
+import styles from './CourseForm.module.css';
 export type ResourceType = 'VIDEO' | 'PDF' | 'DOC' | 'ZIP';
 
 export type UploadResult = {
@@ -177,13 +177,23 @@ export function ResourceUploader({
         setDraftDuration(null);
       }
 
-      const { key } = await createPresignedUploadUrl({
+      const { presignedUrl, key } = await createPresignedUploadUrl({
         fileName: file.name,
         contentType: file.type,
         size: bytesToKB(file.size),
         duration: videoSeconds ?? 0,
         isDownloadable: effectiveType === 'VIDEO' ? false : effectiveIsDownloadable,
       });
+
+      const putRes = await fetch(presignedUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': file.type },
+        body: file,
+      });
+
+      if (!putRes.ok) {
+        throw new Error('파일 업로드(PUT)에 실패했습니다.');
+      }
 
       addDraftResource({
         resourceType: effectiveType,

--- a/src/shared/services/uploadThumbnail.ts
+++ b/src/shared/services/uploadThumbnail.ts
@@ -20,5 +20,17 @@ export async function uploadThumbnail(file: File): Promise<string> {
     requestBody,
   );
 
+  const uploadRes = await fetch(presignedUrl, {
+    method: 'PUT',
+    headers: {
+      'Content-Type': file.type,
+    },
+    body: file,
+  });
+
+  if (!uploadRes.ok) {
+    throw new Error('Thumbnail upload failed');
+  }
+
   return key;
 }


### PR DESCRIPTION
## 변경 사항

- presigned URL 발급 후 실제 파일 업로드(PUT) 단계 추가
- 영상/리소스 업로드 플로우 정상화

## 리뷰 필요

- [x]  presigned URL 응답에서 presignedUrl 사용
- [x]  PUT 요청으로 파일 업로드 처리
- [x]  업로드 완료 후 draft 리소스 상태 갱신
- [x]  (백엔드) 스토리지 CORS 설정 필요

close #159 
