### PR TITLE
fix: 장바구니 삭제 cartItemId 적용 및 중복 담김 방지

### DIFF
--- a/src/domains/cart/pages/CartClientPage.tsx
+++ b/src/domains/cart/pages/CartClientPage.tsx
@@ -141,7 +141,8 @@ export function CartClientPage() {
               instructor: detail.instructor?.name ?? '강사',
               price: detail.price,
               originalPrice: detail.price,
-              thumbnailUrl: detail.thumbnailUrl,
+              // thumbnailUrl: formatAbsoluteUrl(detail?.thumbnailUrl),
+              thumbnailUrl: '/default-thumbnail.png',
             };
 
             setItems((prev) => {
@@ -203,7 +204,7 @@ export function CartClientPage() {
           return;
         }
 
-        await Promise.all(selectedItems.map((it) => deleteCartItem(Number(it.id))));
+        await Promise.all(selectedItems.map((it) => deleteCartItem(Number(it.cartItemId))));
         await refetchCart();
       } catch (e) {
         console.error('장바구니 제거에 실패했습니다.', e);
@@ -358,6 +359,7 @@ export function CartClientPage() {
 const mapCartDetailsToItems = (details: Array<CartItemResponse>) =>
   details.filter(Boolean).map((detail) => ({
     id: Number(detail.courseId),
+    cartItemId: Number(detail.cartItemId),
     title: detail.courseTitle,
     instructor: detail.instructorName ?? '강사',
     price: detail.price,

--- a/src/domains/cart/pages/CartClientPage.tsx
+++ b/src/domains/cart/pages/CartClientPage.tsx
@@ -124,8 +124,17 @@ export function CartClientPage() {
 
   useEffect(() => {
     if (!initialCourseId) return;
+    if (!cartInitializedRef.current) return;
+
+    // courseId 당 1회만 처리
     if (handledInitialCourseIdRef.current === initialCourseId) return;
     handledInitialCourseIdRef.current = initialCourseId;
+
+    const alreadyInCart = items.some((it) => String(it.id) === initialCourseId);
+    if (alreadyInCart) {
+      setSelectedMap(buildSelectOnlyMap(items, initialCourseId));
+      return;
+    }
 
     (async () => {
       setCartMutating(true);
@@ -167,7 +176,7 @@ export function CartClientPage() {
         setCartMutating(false);
       }
     })();
-  }, [initialCourseId]);
+  }, [initialCourseId, items]);
 
   const handleSelectChange = (id: number, checked: boolean) => {
     setSelectedMap((prev) => ({

--- a/src/domains/cart/services/cartService.ts
+++ b/src/domains/cart/services/cartService.ts
@@ -1,4 +1,4 @@
-import { getApi, postApi } from '@/shared/lib/api/fetchApi';
+import { deleteApi, getApi, postApi } from '@/shared/lib/api/fetchApi';
 import {
   AddCartItemRequest,
   AddCartItemResponse,
@@ -49,5 +49,5 @@ export const addCartItem = async ({
  * 장바구니 항목 제거
  */
 export const deleteCartItem = async (cartItemId: number): Promise<DeleteCartItemResponse> => {
-  return await postApi<DeleteCartItemResponse>(`/api/cart/items/${cartItemId}`);
+  return await deleteApi<DeleteCartItemResponse>(`/api/cart/items/${cartItemId}`);
 };

--- a/src/domains/cart/types/cart.ts
+++ b/src/domains/cart/types/cart.ts
@@ -14,7 +14,8 @@ export type ConfirmPaymentRequest = {
 };
 
 export type CartItem = {
-  id: number;
+  id: number; // 강좌 ID
+  cartItemId?: number; // 장바구니 ID
   title: string;
   instructor: string;
   price: number;


### PR DESCRIPTION
## 변경 사항

- 장바구니 삭제 요청을 `courseId` → `cartItemId` 기준으로 변경 (CartItem 타입/응답 매핑/삭제 호출 로직 반영)
- 장바구니 삭제 API 메서드를 `POST` → `DELETE`로 수정 및 `/cart?courseId=...` 진입 시 중복 담김 방지(초기 로딩 가드 + 이미 담긴 경우 add 스킵)

## 리뷰 필요

- 선택 삭제 시 `cartItemId` 기준으로 정상 삭제되는지 확인 부탁드립니다.
- `/cart?courseId=...` 진입 시 동일 강좌가 중복으로 추가되지 않는지 확인 부탁드립니다.

close #156
