### PR TITLE
fix: 학습 진도 저장 시 resourceId undefined 이슈 대응

### DIFF
--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -24,7 +24,8 @@ export function useCourseLearn(options?: UseCourseLearnOptions) {
   const [selectedLectureId, setSelectedLectureId] = useState<string | null>(null);
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(() => new Set());
 
-  const { progressInfo, lectureProgressMap } = useProgress(courseId);
+  const { progressInfo, lectureProgressMap, autoSaveProgress, saveFinalProgressOnEnd } =
+    useProgress(courseId);
 
   useEffect(() => {
     if (!courseId) return;
@@ -78,11 +79,11 @@ export function useCourseLearn(options?: UseCourseLearnOptions) {
   ): UILecture {
     if (!progressInfo) return lectures[0];
 
-    const idx = lectures.findIndex((l) => l.id === progressInfo.lectureId);
+    const idx = lectures.findIndex((l) => l.resourceId === progressInfo.resourceId);
 
     if (idx === -1) return lectures[0];
 
-    const progress = lectureProgressMap.get(progressInfo.lectureId);
+    const progress = lectureProgressMap.get(progressInfo.resourceId);
 
     if (progress?.completed) {
       return lectures[idx + 1] ?? lectures[idx];
@@ -173,5 +174,10 @@ export function useCourseLearn(options?: UseCourseLearnOptions) {
     handleLectureClick,
     toggleSection,
     moveToNextLecture,
+
+    progressInfo,
+    lectureProgressMap,
+    autoSaveProgress,
+    saveFinalProgressOnEnd,
   };
 }

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -58,15 +58,14 @@ export function useProgress(courseId: string) {
 
   // 이어보기 정보
   const progressInfo = useMemo<ProgressInfo | null>(() => {
-    if (!progressData?.lastWatchedResourceId) return null;
+    const id = progressData?.lastWatchedResourceId;
+    if (!id) return null;
 
     // 마지막 watchedDuration은 강의별 목록에서 찾아오는 방식으로 맞춤
-    const last = progressData.lectureProgresses.find(
-      (p) => p.resourceId === progressData.lastWatchedResourceId,
-    );
+    const last = progressData.lectureProgresses.find((p) => p.resourceId === id);
 
     return {
-      lectureId: progressData.lastWatchedResourceId,
+      resourceId: id,
       resumeAt: last?.watchedDuration ?? 0,
     };
   }, [progressData]);
@@ -87,7 +86,7 @@ export function useProgress(courseId: string) {
 
   const pendingRef = useRef<PendingProgress | null>(null); // 저장 실패 시 재시도 대상
 
-  const THROTTLE_INTERVAL = 10; // 저장 최소 호출 간격 (ms)
+  const THROTTLE_INTERVAL = 10_000; // 저장 최소 호출 간격 (ms)
   const MIN_SAVE_DELTA = 3; // 저장할 최소 재생 시간 변화량 (초)
   const RETRY_DELAYS = [2000, 5000, 15000]; // 저장 실패 시 재시도 간격 (ms)
 
@@ -103,7 +102,7 @@ export function useProgress(courseId: string) {
       try {
         // TODO(mock): mock 단계에서는 실제 API 호출 없이 UI 상태만 갱신
         if (!USE_MOCK) {
-          await updateLearnProgress({
+          await updateLearnProgress(courseId, {
             resourceId: pending.resourceId,
             watchedDuration: pending.watchedDuration,
           });
@@ -123,13 +122,14 @@ export function useProgress(courseId: string) {
 
   // 진도 즉시 저장
   const saveProgress = async (resourceId: string, watchedDuration: number) => {
+    if (!resourceId) {
+      console.warn('[progress] missing resourceId -> skip save', { courseId, watchedDuration });
+      return;
+    }
     try {
       // TODO(mock): mock 단계에서는 실제 네트워크 요청 없이 처리
       if (!USE_MOCK) {
-        await updateLearnProgress({
-          resourceId,
-          watchedDuration,
-        });
+        await updateLearnProgress(courseId, { resourceId, watchedDuration });
       }
 
       setProgressData((prev) =>

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -13,11 +13,10 @@ import { useRef, useEffect, useMemo } from 'react';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useCourseLearn } from '@/domains/course/hooks/useCourseLearn';
-import { useProgress } from '@/domains/course/hooks/useProgress';
 import styles from '@/app/courses/[id]/learn/CourseLearnPage.module.css';
 import { formatLectureDuration } from '@/domains/course/utils/formatDuration';
-import { formatAbsoluteUrl } from '../utils/formatAbsoluteUrl';
-import { LearnEnrollmentResponse } from '../types/learn';
+import { formatAbsoluteUrl } from '@/domains/course/utils/formatAbsoluteUrl';
+import { LearnEnrollmentResponse } from '@/domains/course/types/learn';
 
 type CourseLearnClientProps = {
   enrollment: LearnEnrollmentResponse;
@@ -39,9 +38,10 @@ export default function CourseLearnClient({ enrollment }: CourseLearnClientProps
     toggleSection,
     handleLectureClick,
     moveToNextLecture,
+    lectureProgressMap,
+    autoSaveProgress,
+    saveFinalProgressOnEnd,
   } = useCourseLearn({ start });
-  const { progressInfo, autoSaveProgress, saveFinalProgressOnEnd, lectureProgressMap } =
-    useProgress(enrollment.courseId);
 
   const totalLectures = useMemo(() => {
     if (!courseData) return 0;
@@ -68,23 +68,20 @@ export default function CourseLearnClient({ enrollment }: CourseLearnClientProps
     const video = videoRef.current;
     if (!video) return;
     if (!currentLecture) return;
-    if (!progressInfo) return;
     if (hasSeekedRef.current) return;
 
-    if (progressInfo.lectureId !== currentLecture.id) return;
+    const saved = lectureProgressMap.get(currentLecture.resourceId)?.watchedDuration ?? 0;
 
     const handleLoadedMetadata = () => {
-      if (progressInfo.resumeAt < video.duration) {
-        video.currentTime = progressInfo.resumeAt;
+      if (saved > 0 && saved < video.duration) {
+        video.currentTime = saved;
       }
       hasSeekedRef.current = true;
     };
 
     video.addEventListener('loadedmetadata', handleLoadedMetadata);
-    return () => {
-      video.removeEventListener('loadedmetadata', handleLoadedMetadata);
-    };
-  }, [currentLecture?.id, progressInfo]);
+    return () => video.removeEventListener('loadedmetadata', handleLoadedMetadata);
+  }, [currentLecture?.resourceId, lectureProgressMap]);
 
   if (!courseData || !currentLecture) {
     return <div className={styles['course-learn__loading']}>강의를 불러오는 중입니다...</div>;
@@ -132,8 +129,9 @@ export default function CourseLearnClient({ enrollment }: CourseLearnClientProps
                   controls
                   autoPlay
                   onEnded={() => {
-                    if (!currentLecture.duration) return;
-                    saveFinalProgressOnEnd(currentLecture.resourceId, currentLecture.duration);
+                    const video = videoRef.current;
+                    const t = video ? Math.floor(video.currentTime) : 0;
+                    saveFinalProgressOnEnd(currentLecture.resourceId, t);
                     moveToNextLecture();
                   }}
                   onTimeUpdate={(e) => {
@@ -159,7 +157,7 @@ export default function CourseLearnClient({ enrollment }: CourseLearnClientProps
                 {currentLecture.pdfUrl && (
                   <a href={formatAbsoluteUrl(currentLecture.pdfUrl)} download>
                     <button
-                      onClick={() => saveFinalProgressOnEnd(currentLecture.id, 0)}
+                      onClick={() => saveFinalProgressOnEnd(currentLecture.resourceId, 0)}
                       className={styles['course-learn__brand-btn']}
                     >
                       <Download className={styles['course-learn__icon']} /> PDF 다운로드

--- a/src/domains/course/services/learnService.ts
+++ b/src/domains/course/services/learnService.ts
@@ -18,7 +18,8 @@ export async function getLearnProgress(courseId: string): Promise<GetProgressRes
 
 // 진도율 갱신
 export async function updateLearnProgress(
+  courseId: string,
   payload: UpdateProgressRequest,
 ): Promise<UpdateProgressResponse> {
-  return patchApi<UpdateProgressResponse>(`/api/progresses/${payload.resourceId}`, payload);
+  return patchApi<UpdateProgressResponse>(`/api/progresses/${courseId}`, payload);
 }

--- a/src/domains/course/types/learn.ts
+++ b/src/domains/course/types/learn.ts
@@ -58,7 +58,7 @@ export type LearnEnrollmentResponse = {
 // Domain: Course + Enrollment
 export type CourseLearn = {
   course: LearnCourseResponse;
-  enrollment: LearnEnrollmentResponse;
+  enrollment: LearnEnrollmentResponse | null;
 };
 
 // UI Types (Learn Page)

--- a/src/domains/course/types/progress.ts
+++ b/src/domains/course/types/progress.ts
@@ -32,7 +32,7 @@ export type UpdateProgressResponse = {
 
 // 이어보기 정보
 export type ProgressInfo = {
-  lectureId: string;
+  resourceId: string;
   resumeAt: number;
 };
 


### PR DESCRIPTION
## 변경 사항

- 학습 페이지 진도/이어보기/완료 판단 기준을 `resourceId`로 통일 (lectureId 기반 로직 제거)
- 진도 저장 로직 안정화
  - `resourceId` undefined 가드 추가 (save/autoSave/ended)
  - 영상 종료 시 최종 저장 값을 `duration` 대신 `video.currentTime` 기준으로 저장하도록 수정
  - `THROTTLE_INTERVAL` 조정으로 과도한 저장 호출 방지
- 중복 상태 생성 방지: 
  - `useProgress`를 `useCourseLearn` 내부로 통합
  - Learn Client에서 `useCourseLearn` 반환값을 사용하도록 변경
- 타입/도메인 정리
  - `ProgressInfo`: `lectureId -> resourceId`로 변경
  - `CourseLearn.enrollment`에 `null` 허용

## 리뷰 필요

- **백엔드 의존 이슈(진도 정상 동작을 위해 필요)**
  - 강좌 상세 조회 응답(`GET /api/courses/:courseId`)에서 각 강의에 `resourceId`(`lecture.resource.resourceId`)가 누락되는 케이스가 있어, 프론트에서 `currentLecture.resourceId`가 undefined로 떨어질 수 있습니다.
    → 효진님께 **강의에 `resourceId` 프로퍼티 포함** 요청 드려둔 상태입니다.  
    (현재는 누락 케이스에서 저장 호출을 스킵하도록 가드 처리되어 UI는 유지되지만, 진도 갱신은 제한됩니다.)
  - **`getLearnProgress`가 현재 목업 데이터를 반환하는 문제**도 있어, 선욱님께 공유 드렸고 반영되길 대기 중입니다.
- **동작 확인 포인트**
  - 영상 재생 중 일정 간격으로 진도 저장되는지 (throttle 동작)
  - 강의 종료 시 최종 진도 저장이 `currentTime` 기준으로 반영되는지
  - 진도 데이터 없는 첫 진입에서도 UI가 깨지지 않는지(이어보기 null 케이스 fallback)

close #163
