### PR TITLE
fix: 헤더 드롭다운이 FloatingCTA에 가려지는 이슈 해결

### DIFF
--- a/src/shared/ui/Header.module.css
+++ b/src/shared/ui/Header.module.css
@@ -1,7 +1,7 @@
 .header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: 1000;
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--color-border);
@@ -184,7 +184,7 @@
   padding: 8px 0;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   min-width: 140px;
-  z-index: 20;
+  z-index: 1000;
 }
 
 .header__dropdown-item {

--- a/src/shared/ui/Header.tsx
+++ b/src/shared/ui/Header.tsx
@@ -9,8 +9,8 @@ import { useModal } from '@/shared/hooks/useModal';
 import { LoginModal } from '@/domains/auth/components/LoginModal';
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import { logoutAction } from '@/domains/auth/actions/logoutAction';
-import styles from './Header.module.css';
 import { useCourseCreateEntry } from '@/domains/course/hooks/useCourseCreateEntry';
+import styles from './Header.module.css';
 
 export function Header() {
   const router = useRouter();


### PR DESCRIPTION
## 변경 사항

- Header 컨테이너 레이어 우선순위 조정: .header에 position + z-index 상향 적용

close #165 
