### PR TITLE
refactor: 수강 도메인 진도율 처리 및 상태 기반 UI 가드 정리

### DIFF
--- a/src/domains/course/types/course.ts
+++ b/src/domains/course/types/course.ts
@@ -262,18 +262,6 @@ export type GetCourseDetailResponse = {
   };
 };
 
-export type EnrollmentStatus = 'ENROLLED' | 'COMPLETED' | 'CANCELED' | 'EXPIRED';
-
-export type GetEnrollmentResponse = {
-  enrollmentId: string;
-  studentId: string;
-  courseId: string;
-  status: EnrollmentStatus;
-  progressRate: number;
-  createdAt: string;
-  expiredAt: string;
-};
-
 export type SectionDetailResponse = {
   sectionId: string;
   title: string;

--- a/src/domains/user/pages/EnrollmentClientPage.tsx
+++ b/src/domains/user/pages/EnrollmentClientPage.tsx
@@ -11,17 +11,15 @@ import CourseReviewModal from '@/domains/course/components/CourseReviewModal';
 import { MOCK_GET_COURSE_REVIEWS } from '@/mocks/review.mock';
 import { useCourseReviews } from '@/domains/course/hooks/useCourseReview';
 import { USE_MOCK } from '@/shared/constants/config';
-import { getEnrollmentList } from '../services/enrollmentService';
 import { getIsReviewed } from '@/domains/course/services/reviewService';
+import { getEnrollmentList } from '../services/enrollmentService';
+import { getEnrollmentProgressRate } from '../utils/enrollmentProgress';
 
 export default function EnrollmentClientPage() {
   const [items, setItems] = useState<EnrollmentListContent[]>([]);
   const [loading, setLoading] = useState(true);
-
   const [reviewTarget, setReviewTarget] = useState<EnrollmentListContent | null>(null);
   const [isReviewOpen, setIsReviewOpen] = useState(false);
-
-  const [enrolledLoading, setEnrolledLoading] = useState<boolean>(false);
   const router = useRouter();
 
   const selectedCourseId = useMemo(
@@ -82,7 +80,7 @@ export default function EnrollmentClientPage() {
 
   useEffect(() => {
     async function fetchEnrollments() {
-      setEnrolledLoading(true);
+      setLoading(true);
       try {
         // TODO(mock): 개발 중 환경변수로 수강 목록 및 리뷰 상태를 mock 데이터로 구성
         const page = USE_MOCK ? MOCK_ENROLLMENT_LIST : await getEnrollmentList();
@@ -137,6 +135,10 @@ export default function EnrollmentClientPage() {
 
       <div className={styles['enrollment-section__list']}>
         {items.map((item) => {
+          const rate = getEnrollmentProgressRate(item);
+          const canLearn = item.status === 'ENROLLED' || item.status === 'COMPLETED';
+          const canReview = item.status === 'COMPLETED';
+
           return (
             <div key={item.enrollmentId} className={styles['enrollment-card']}>
               <div className={styles['enrollment__link']}>
@@ -153,35 +155,36 @@ export default function EnrollmentClientPage() {
                 </div>
 
                 <div className={styles['enrollment-card__actions']}>
-                  <button
-                    type="button"
-                    className={styles['enrollment__review-btn']}
-                    onClick={(e) => {
-                      e.preventDefault();
-                      e.stopPropagation();
-                      openReviewModal(item);
-                    }}
-                  >
-                    {item.isReviewed ? '리뷰 수정' : '리뷰 작성'}
-                  </button>
-                  <Link
-                    href={`/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}`}
-                    className={styles['btn-primary']}
-                    aria-label="학습하기"
-                  >
-                    <Play />
-                  </Link>
+                  {canReview && (
+                    <button
+                      type="button"
+                      className={styles['enrollment__review-btn']}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        openReviewModal(item);
+                      }}
+                    >
+                      {item.isReviewed ? '리뷰 수정' : '리뷰 작성'}
+                    </button>
+                  )}
+                  {canLearn && (
+                    <Link
+                      href={`/courses/${item.courseId}/learn?enrollmentId=${item.enrollmentId}`}
+                      className={styles['btn-primary']}
+                      aria-label="학습하기"
+                    >
+                      <Play />
+                    </Link>
+                  )}
                 </div>
               </div>
 
               <div className={styles['progress']}>
-                <div
-                  className={styles['progress__bar']}
-                  style={{ width: `${item.progressRate ?? 0}%` }}
-                />
+                <div className={styles['progress__bar']} style={{ width: `${rate}%` }} />
               </div>
 
-              <span className={styles['enrollment-card__percent']}>{item.progressRate ?? 0}%</span>
+              <span className={styles['enrollment-card__percent']}>{rate}%</span>
             </div>
           );
         })}

--- a/src/domains/user/services/enrollmentService.ts
+++ b/src/domains/user/services/enrollmentService.ts
@@ -25,7 +25,7 @@ export const getEnrollmentByCourseId = async (
 // 수강 정보 조회 (수강 ID 기준)
 export async function getEnrollmentByEnrollmentId(
   enrollmentId: string,
-): Promise<EnrollmentDetailResponse> {
+): Promise<GetEnrollmentResponse> {
   return getApi(`/api/enrollments/${enrollmentId}`, { cache: 'no-store' });
 }
 

--- a/src/domains/user/services/enrollmentService.ts
+++ b/src/domains/user/services/enrollmentService.ts
@@ -2,16 +2,16 @@ import { getApi } from '@/shared/lib/api/fetchApi';
 import type {
   EnrollmentListResponse,
   EnrollmentDetailResponse,
+  EnrollmentStatus,
 } from '@/domains/user/types/enrollment';
-import { LearnEnrollmentResponse } from '@/domains/course/types/learn';
-import { GetEnrollmentResponse } from '@/domains/course/types/course';
+import type { GetEnrollmentResponse as EnrollmentByCourseResponse } from '@/domains/course/types/course';
 
 // 수강 정보 조회 (강좌 ID 기준)
 export const getEnrollmentByCourseId = async (
   courseId: string,
-): Promise<GetEnrollmentResponse | null> => {
+): Promise<EnrollmentByCourseResponse | null> => {
   try {
-    return await getApi<GetEnrollmentResponse | null>(`/api/enrollments/course/${courseId}`, {
+    return await getApi<EnrollmentByCourseResponse | null>(`/api/enrollments/course/${courseId}`, {
       cache: 'no-store',
     });
   } catch (err) {
@@ -25,12 +25,12 @@ export const getEnrollmentByCourseId = async (
 // 수강 정보 조회 (수강 ID 기준)
 export async function getEnrollmentByEnrollmentId(
   enrollmentId: string,
-): Promise<LearnEnrollmentResponse> {
+): Promise<EnrollmentDetailResponse> {
   return getApi(`/api/enrollments/${enrollmentId}`, { cache: 'no-store' });
 }
 
 export async function getEnrollmentList(params?: {
-  status?: string;
+  status?: EnrollmentStatus;
   page?: number;
   size?: number;
 }): Promise<EnrollmentListResponse> {
@@ -41,12 +41,6 @@ export async function getEnrollmentList(params?: {
   });
 
   return await getApi<EnrollmentListResponse>(`/api/enrollments?${query.toString()}`, {
-    cache: 'no-store',
-  });
-}
-
-export async function getEnrollmentDetail(enrollmentId: string): Promise<EnrollmentDetailResponse> {
-  return await getApi<EnrollmentDetailResponse>(`/api/enrollments/${enrollmentId}`, {
     cache: 'no-store',
   });
 }

--- a/src/domains/user/services/enrollmentService.ts
+++ b/src/domains/user/services/enrollmentService.ts
@@ -3,15 +3,15 @@ import type {
   EnrollmentListResponse,
   EnrollmentDetailResponse,
   EnrollmentStatus,
+  GetEnrollmentResponse,
 } from '@/domains/user/types/enrollment';
-import type { GetEnrollmentResponse as EnrollmentByCourseResponse } from '@/domains/course/types/course';
 
 // 수강 정보 조회 (강좌 ID 기준)
 export const getEnrollmentByCourseId = async (
   courseId: string,
-): Promise<EnrollmentByCourseResponse | null> => {
+): Promise<GetEnrollmentResponse | null> => {
   try {
-    return await getApi<EnrollmentByCourseResponse | null>(`/api/enrollments/course/${courseId}`, {
+    return await getApi<GetEnrollmentResponse | null>(`/api/enrollments/course/${courseId}`, {
       cache: 'no-store',
     });
   } catch (err) {

--- a/src/domains/user/types/enrollment.ts
+++ b/src/domains/user/types/enrollment.ts
@@ -6,6 +6,7 @@ export type EnrollmentListContent = {
   courseId: string;
   courseName: string;
   status: EnrollmentStatus;
+  // TODO: 백엔드 전환 완료 후 progressRate 제거하고 overallProgressRate로 통합
   progressRate?: number;
   overallProgressRate?: number;
   expiredAt: string;
@@ -27,6 +28,7 @@ export type EnrollmentDetailResponse = {
   studentId: string;
   courseId: string;
   status: EnrollmentStatus;
+  // TODO: 백엔드 전환 완료 후 progressRate 제거하고 overallProgressRate로 통합
   progressRate?: number;
   overallProgressRate?: number;
   createdAt: string;

--- a/src/domains/user/types/enrollment.ts
+++ b/src/domains/user/types/enrollment.ts
@@ -6,7 +6,8 @@ export type EnrollmentListContent = {
   courseId: string;
   courseName: string;
   status: EnrollmentStatus;
-  progressRate: number;
+  progressRate?: number;
+  overallProgressRate?: number;
   expiredAt: string;
   categories: string[];
   isReviewed?: boolean; // TODO: 추후에 변경 가능성
@@ -26,23 +27,13 @@ export type EnrollmentDetailResponse = {
   studentId: string;
   courseId: string;
   status: EnrollmentStatus;
-  progressRate: number;
+  progressRate?: number;
+  overallProgressRate?: number;
   createdAt: string;
   expiredAt: string;
-};
-
-// 3) 진도 조회 (GET /api/progresses/{enrollmentId})
-export type EnrollmentProgressResponse = {
-  resourceId: string;
-  enrollmentId: string;
-  progressRate: number;
-  lastVideoId: string;
-  lastWatchedDuration: number;
-  updatedAt: string;
 };
 
 // 4) Learn 페이지 전용 묶음 타입
 export type EnrollmentLearnData = {
   enrollment: EnrollmentDetailResponse | null;
-  progress: EnrollmentProgressResponse | null;
 };

--- a/src/domains/user/types/enrollment.ts
+++ b/src/domains/user/types/enrollment.ts
@@ -22,6 +22,18 @@ export type EnrollmentListResponse = {
   pageSize: number;
 };
 
+export type GetEnrollmentResponse = {
+  enrollmentId: string;
+  studentId: string;
+  courseId: string;
+  status: EnrollmentStatus;
+  // TODO: 백엔드 전환 완료 후 progressRate 제거하고 overallProgressRate로 통합
+  progressRate?: number;
+  overallProgressRate?: number;
+  createdAt: string;
+  expiredAt: string;
+};
+
 // 2) 수강 단건 조회 (GET /api/enrollments/{enrollmentId})
 export type EnrollmentDetailResponse = {
   enrollmentId: string;

--- a/src/domains/user/utils/enrollmentProgress.ts
+++ b/src/domains/user/utils/enrollmentProgress.ts
@@ -1,0 +1,4 @@
+export const getEnrollmentProgressRate = (e: {
+  progressRate?: number;
+  overallProgressRate?: number;
+}) => e.overallProgressRate ?? e.progressRate ?? 0;

--- a/src/domains/user/utils/enrollmentProgress.ts
+++ b/src/domains/user/utils/enrollmentProgress.ts
@@ -1,4 +1,5 @@
 export const getEnrollmentProgressRate = (e: {
+  // TODO: backend overallProgressRate 전환 완료 시 progressRate fallback 제거
   progressRate?: number;
   overallProgressRate?: number;
 }) => e.overallProgressRate ?? e.progressRate ?? 0;


### PR DESCRIPTION
## 변경 사항

- 백엔드에서 공유한 Enrollment / Progress API 명세를 기준으로 수강(Enrollment) 도메인 리팩토링
- 진도율 필드 변경(`progressRate → overallProgressRate`)에 대비한 공통 유틸 도입
- 수강 상태(ENROLLED / COMPLETED / CANCELED / EXPIRED)에 따른 UI 접근 가드 정리

### 상세
- Enrollment 타입에서 진도율 필드 optional 처리
- 진도율 계산 로직을 도메인 유틸로 분리 (`getEnrollmentProgressRate`)
- 수강 상태 기반으로 학습/리뷰 버튼 노출 제어
- 강좌별 수강 여부 조회 API(404 = 미수강) 처리 명확화

close #184
