### PR TITLE
fix: 검색시 url 초기화 fix, 

### DIFF
--- a/src/domains/course/components/SearchBar.tsx
+++ b/src/domains/course/components/SearchBar.tsx
@@ -6,7 +6,7 @@ import { useCourseListQuery } from '../hooks/useCourseListQuery';
 import styles from './SearchBar.module.css';
 
 export function SearchBar() {
-  const { keyword, setKeyword } = useCourseListQuery();
+  const { keyword, searchByKeyword } = useCourseListQuery();
   const [inputValue, setInputValue] = useState(keyword);
 
   useEffect(() => {
@@ -17,7 +17,7 @@ export function SearchBar() {
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    setKeyword(inputValue.trim());
+    searchByKeyword(inputValue.trim());
     setInputValue('');
   };
 

--- a/src/domains/course/hooks/useCourseListQuery.tsx
+++ b/src/domains/course/hooks/useCourseListQuery.tsx
@@ -27,7 +27,7 @@ interface UseCourseListQueryReturn extends CourseListQueryState {
     keyword: string | null,
   ) => void;
   setLevel: (value: CourseLevel | null) => void;
-  setKeyword: (value: string) => void;
+  searchByKeyword: (value: string) => void;
 }
 
 const VALID_LEVELS: CourseLevel[] = ['BEGINNER', 'NOVICE', 'INTERMEDIATE', 'ADVANCED'];
@@ -133,8 +133,15 @@ export function useCourseListQuery(): UseCourseListQueryReturn {
     [updateParams],
   );
 
-  const setKeyword = useCallback(
-    (value: string) => updateParams({ keyword: value || null, page: null }),
+  const searchByKeyword = useCallback(
+    (value: string) =>
+      updateParams({
+        keyword: value || null,
+        categoryId: null,
+        level: null,
+        sort: null,
+        page: null,
+      }),
     [updateParams],
   );
 
@@ -152,6 +159,6 @@ export function useCourseListQuery(): UseCourseListQueryReturn {
     setCategoryAndKeyword,
     setCategoryLevelAndKeyword,
     setLevel,
-    setKeyword,
+    searchByKeyword,
   };
 }

--- a/src/domains/course/pages/CourseListClientPage.tsx
+++ b/src/domains/course/pages/CourseListClientPage.tsx
@@ -24,20 +24,9 @@ export default function CourseListClientPage() {
   const [categoryMap, setCategoryMap] = useState<Record<string, CategoryMapEntry>>({});
   const [categoryIdToName, setCategoryIdToName] = useState<Record<number, string>>({});
   const [loading, setLoading] = useState<boolean>(true);
-  const [totalPages, setTotalPages] = useState(0);
-  const [hasNext, setHasNext] = useState(false);
 
-  const {
-    sort,
-    page,
-    size,
-    categoryId,
-    level,
-    keyword,
-    setPage,
-    setCategoryId,
-    setCategoryLevelAndKeyword,
-  } = useCourseListQuery();
+  const { sort, page, size, categoryId, level, keyword, setCategoryLevelAndKeyword } =
+    useCourseListQuery();
 
   const handleSelectCategory = (nextCategoryId: number | null) => {
     setCategoryLevelAndKeyword(nextCategoryId, null, null);
@@ -130,8 +119,6 @@ export default function CourseListClientPage() {
         }));
 
         setCourses(courseCardData);
-        setTotalPages(data.totalPages);
-        setHasNext(data.hasNext);
       } catch (error) {
         console.error('강좌 목록 불러오기 실패:', error);
       } finally {


### PR DESCRIPTION
## 변경 사항

- 검색 사용시 기존 카테고리 및 sort 가 입력된 상태로 URL 초기화 되지 않던 것 해결
- 추가로 무한스크롤 적용으로 사용되지 않는 set 값들 삭제함. 
   단, API response 에는 포함되어 있기 때문에 타입 정의에 필드가 포함되어 있어서     
   totalElements 와 totalPagesValue 는 삭제 하지 않음

## 리뷰 필요

- 검색 입력시 URL 확인
- 무한 스크롤 적용으로 사용되지 않는 set 삭제 여부 확인

close #198 
