### PR TITLE
fix: 강좌 목록 조회 쿼리 파라미터 적용 오류 수정

### DIFF
--- a/src/domains/course/pages/CourseListClientPage.tsx
+++ b/src/domains/course/pages/CourseListClientPage.tsx
@@ -162,6 +162,7 @@ export default function CourseListClientPage() {
       <section className={styles['course-list__content']} aria-label="강좌 카드 목록">
         <div className={styles['course-list__toolbar']}>
           <LevelSelect />
+          {/* TODO: 강좌 목록 조회 API는 정렬 추후에 반영 */}
           <SortSelect />
         </div>
         {loading ? (

--- a/src/domains/course/services/courseService.ts
+++ b/src/domains/course/services/courseService.ts
@@ -27,10 +27,9 @@ export const getAllCourses = async (
   if (params?.categoryId != null) query.set('categoryId', String(params.categoryId));
   if (params?.level) query.set('level', params.level);
   if (params?.keyword) query.set('keyword', params.keyword);
-  if (params?.sort) query.set('sort', params.sort);
+  // if (params?.sort) query.set('sort', params.sort);
 
-  const qs = query.toString();
-  const response = await fetch(`${BASE_URL}/api/courses${query.toString()}`, {
+  const response = await fetch(`${BASE_URL}/api/courses?${query.toString()}`, {
     method: 'GET',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## 변경 사항

- 강좌 목록 조회 API 함수 수정
  - 쿼리 파라미터가 누락되던 이슈 해결
  - `sort` 값이 의도치 않게 함께 포함되던 이슈 해결
- SortSelect 호출부 TODO 추가

close #202