### PR TITLE
fix: enrollment 타입 import 오류 및 learn 페이지 가드 연동 수정

### DIFF
--- a/src/app/courses/[id]/learn/page.tsx
+++ b/src/app/courses/[id]/learn/page.tsx
@@ -3,7 +3,7 @@ import { requireLearn } from '@/shared/guards/RequireLearn';
 
 export default async function CourseLearnPage({ params }: { params: Promise<{ id: string }> }) {
   const { id: courseId } = await params;
-  const { enrollment } = await requireLearn(courseId);
+  await requireLearn(courseId);
 
-  return <CourseLearnClient enrollment={enrollment} />;
+  return <CourseLearnClient />;
 }

--- a/src/mocks/enrollmentList.mock.ts
+++ b/src/mocks/enrollmentList.mock.ts
@@ -1,5 +1,7 @@
-import type { GetEnrollmentResponse } from '@/domains/course/types/course';
-import type { EnrollmentListResponse } from '@/domains/user/types/enrollment';
+import type {
+  EnrollmentListResponse,
+  GetEnrollmentResponse,
+} from '@/domains/user/types/enrollment';
 
 export const MOCK_ENROLLMENT_LIST: EnrollmentListResponse = {
   content: [


### PR DESCRIPTION
## 변경 사항
- enrollment mock에서 잘못된 도메인 타입(course → user) import 수정
- enrollment 타입 정리 이후 learn 페이지에서 불필요한 enrollment prop 전달 제거
- requireLearn 가드에서 수강 여부만 검증하도록 역할 정리

## 리뷰 필요
- enrollment 타입 정리 이후 mock / 실제 API 흐름이 일관되게 맞는지
- learn 페이지 진입 가드 동작이 기존 의도(수강 여부 검증)에 맞는지

close #205 
