### PR TITLE
fix: 강좌 목록/상세 조회 배포사이트 반영 실패(CORS) 이슈 해결

### DIFF
--- a/src/domains/course/services/courseService.ts
+++ b/src/domains/course/services/courseService.ts
@@ -31,9 +31,7 @@ export const getAllCourses = async (
 
   const response = await fetch(`${BASE_URL}/api/courses?${query.toString()}`, {
     method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { Accept: 'application/json' },
   });
   if (!response.ok) {
     throw new Error(`강좌 목록 조회 실패: ${response.statusText}`);
@@ -42,15 +40,14 @@ export const getAllCourses = async (
 
   return resJson.data;
 };
+
 /**
  * 강좌 상세 조회
  */
 export const getCourseDetail = async (courseId: string): Promise<GetCourseDetailResponse> => {
   const response = await fetch(`${BASE_URL}/api/courses/${courseId}`, {
     method: 'GET',
-    headers: {
-      'Content-Type': 'application/json',
-    },
+    headers: { Accept: 'application/json' },
   });
   if (!response.ok) {
     throw new Error(`강좌 상세 조회 실패: ${response.statusText}`);


### PR DESCRIPTION
## 변경 사항

- 강좌 목록/상세 GET 요청에서 불필요한 헤더 제거(Content-Type, ngrok-skip-browser-warning)
- Accept: application/json만 사용하도록 정리

close #210 
