### PR TITLE
fix: 강좌 썸네일 업로드 Presigned URL 변경 대응 및 조회 반영

### DIFF
--- a/src/domains/cart/components/CartItem.tsx
+++ b/src/domains/cart/components/CartItem.tsx
@@ -43,8 +43,7 @@ export const CartItem: React.FC<Props> = ({ item, checked = false, onSelectChang
       </label>
       <div className={styles['cart-item__thumb']}>
         <Image
-          // TODO: 썸네일 임시 처리 - formatAbsoluteUrl(course.thumbnailUrl)
-          src={'/default-thumbnail.png'}
+          src={item.thumbnailUrl ?? '/default-thumbnail.png'}
           alt={`${item.title} 썸네일`}
           width={160}
           height={90}

--- a/src/domains/cart/pages/CartClientPage.tsx
+++ b/src/domains/cart/pages/CartClientPage.tsx
@@ -150,8 +150,7 @@ export function CartClientPage() {
               instructor: detail.instructor?.name ?? '강사',
               price: detail.price,
               originalPrice: detail.price,
-              // thumbnailUrl: formatAbsoluteUrl(detail?.thumbnailUrl),
-              thumbnailUrl: '/default-thumbnail.png',
+              thumbnailUrl: detail?.thumbnailUrl ?? '/default-thumbnail.png',
             };
 
             setItems((prev) => {

--- a/src/domains/course/components/CourseCard.tsx
+++ b/src/domains/course/components/CourseCard.tsx
@@ -22,7 +22,7 @@ export function CourseCard({ course }: CourseCardProps) {
           height={675}
           className={styles['course-card__thumb']}
           // TODO: 썸네일 임시 처리 - formatAbsoluteUrl(course.thumbnailUrl)
-          src={'/default-thumbnail.png'}
+          src={course.thumbnailUrl}
           alt={`${course.title} 썸네일`}
           loading="lazy"
         />

--- a/src/domains/course/pages/CourseDetailClientPage.tsx
+++ b/src/domains/course/pages/CourseDetailClientPage.tsx
@@ -12,13 +12,11 @@ import { useCourseApply } from '@/domains/course/hooks/useCourseApply';
 import { useCourseDetail } from '@/domains/course/hooks/useCourseDetail';
 import { formatDuration } from '@/domains/course/utils/formatDuration';
 import styles from '@/app/courses/[id]/CourseDetailPage.module.css';
-import { MOCK_GET_CART } from '@/mocks/cart.mock';
 import { addCartItem } from '@/domains/cart/services/cartService';
 import { useAuthState } from '@/domains/auth/hooks/useAuthState';
 import { USE_MOCK } from '@/shared/constants/config';
 import type { Section, Lecture } from '../types/course';
 import { LEVEL_LABEL } from '../constants/level';
-import { formatAbsoluteUrl } from '../utils/formatAbsoluteUrl';
 import CoursePreviewModal from '../components/CoursePreviewModal';
 import CourseReviewModal from '../components/CourseReviewModal';
 import { useCourseReviews } from '../hooks/useCourseReview';
@@ -155,8 +153,7 @@ export default function CourseDetailClientPage() {
           width={800}
           height={450}
           className={styles['course-detail__hero']}
-          // TODO: 썸네일 임시 처리 - formatAbsoluteUrl(course.thumbnailUrl)
-          src={'/default-thumbnail.png'}
+          src={course.thumbnailUrl}
           alt={`${course.title} 썸네일`}
           loading="lazy"
         />

--- a/src/domains/course/services/thumbnailService.ts
+++ b/src/domains/course/services/thumbnailService.ts
@@ -18,7 +18,7 @@ export async function createCourseThumbnailPresignedUrl(
   payload: CreateCourseThumbnailPresignedUrlRequest,
 ) {
   return postApi<CreateCourseThumbnailPresignedUrlResponse>(
-    '/api/uploads/courses/thumbnails/presign',
+    '/api/instructor/resource/thumbnail',
     payload,
   );
 }


### PR DESCRIPTION
## 변경 사항

- 썸네일 Presigned URL 발급 API 엔드포인트 변경에 맞춰 요청 경로 변경(`/api/instructor/resource/thumbnail`)
- 강좌 목록/상세/장바구니에서 썸네일 미존재 시, 기본 썸네일 노출 처리

## 리뷰 필요

- (추후) Next Image 및 config 처리(절대 경로/remotePatterns 등) 정리가 필요해 보입니다. 확인 부탁드립니다.

close #209
