### PR TITLE
fix: 타입 변경 반영 및 폼/시청 로직 오류 수정

### DIFF
--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -116,7 +116,7 @@ export default function CourseLearnClient() {
                       time: t,
                     });
 
-                    saveFinalProgressOnEnd(currentLecture.resourceId, t);
+                    saveFinalProgressOnEnd(currentLecture.resourceId);
                     moveToNextLecture();
                   }}
                   onTimeUpdate={(e) => {
@@ -142,7 +142,7 @@ export default function CourseLearnClient() {
                 {currentLecture.pdfUrl && (
                   <a href={toPublicAssetUrl(currentLecture.pdfUrl)} download>
                     <button
-                      onClick={() => saveFinalProgressOnEnd(currentLecture.resourceId, 0)}
+                      onClick={() => saveFinalProgressOnEnd(currentLecture.resourceId)}
                       className={styles['course-learn__brand-btn']}
                     >
                       <Download className={styles['course-learn__icon']} /> PDF 다운로드

--- a/src/domains/course/utils/courseCreate.ts
+++ b/src/domains/course/utils/courseCreate.ts
@@ -4,11 +4,13 @@ import {
   CourseDraftForm,
   CreateCourseRequest,
   CreateLectureRequest,
+  GetDraftCourseResponse,
   LectureDraftForm,
   SectionDraftForm,
 } from '../types/course';
+import { CourseFormState } from './courseDraft';
 
-export const createCourseFormData = (data: any, file?: File) => {
+export const createCourseFormData = (data: CourseFormState, file?: File) => {
   const formData = new FormData();
 
   formData.append('request', new Blob([JSON.stringify(data)], { type: 'application/json' }));
@@ -28,6 +30,7 @@ export const mapDraftToCreateRequest = (draft: CourseDraftForm): CreateCourseReq
     summary: draft.summary,
     description: draft.description,
     categoryId, // number
+    thumbnailResourceKey: draft.thumbnailResourceKey,
     price: draft.price,
     courseLevel: draft.level,
   };
@@ -86,43 +89,42 @@ export const applySectionDraftsForNewCourse = async (
 };
 
 // 생성된 강좌조회 용 데이터 매핑 함수
-export const mapResponseToCourseDraft = (data: any) => {
-  // categoryIds가 배열로 오면 그대로 string 배열로 저장
-  const category = Array.isArray(data.categoryIds)
-    ? data.categoryIds.map((id: unknown) => String(id))
-    : data.category
-      ? [String(data.category)]
-      : [];
+export const mapResponseToCourseDraft = (data: GetDraftCourseResponse) => {
+  const { courseDraft, sectionDrafts } = data;
 
-  const courseDraft: CourseDraftForm = {
-    title: data.title ?? '',
-    summary: data.summary ?? '',
-    description: data.description ?? '',
-    thumbnail: data.thumbnailUrl ?? '',
-    category,
-    level: data.courseLevel ?? 'BEGINNER',
-    price: data.price ?? 0,
+  const newCourseDraft: CourseDraftForm = {
+    title: courseDraft?.title ?? '',
+    summary: courseDraft?.summary ?? '',
+    description: courseDraft?.description ?? '',
+    thumbnail: courseDraft?.thumbnail ?? '',
+    thumbnailResourceKey: courseDraft?.thumbnailResourceKey ?? '',
+    category: Array.isArray(courseDraft?.category)
+      ? courseDraft.category.map((id) => String(id))
+      : [],
+    level: courseDraft?.level ?? 'BEGINNER',
+    price: courseDraft?.price ?? 0,
+    status: courseDraft?.status,
   };
 
-  // SectionDraftForm / LectureDraftForm 필드에 맞춰 최소 매핑
-  const sectionDrafts: SectionDraftForm[] = (data.sections ?? []).map((sec: any) => ({
-    localId: String(sec.id ?? crypto.randomUUID?.() ?? Date.now()),
+  const newSectionDrafts: SectionDraftForm[] = (sectionDrafts ?? []).map((sec) => ({
+    localId: sec.localId ?? String(sec.id ?? crypto.randomUUID?.() ?? Date.now()),
     id: String(sec.id ?? ''),
     title: sec.title ?? '',
-    _dirty: false,
-    _deleted: false,
-    lectures: (sec.lectures ?? []).map((lec: any) => ({
-      localId: String(lec.id ?? crypto.randomUUID?.() ?? Date.now()),
+    _dirty: !!sec._dirty,
+    _deleted: !!sec._deleted,
+    lectures: (sec.lectures ?? []).map((lec) => ({
+      localId: lec.localId ?? String(lec.id ?? crypto.randomUUID?.() ?? Date.now()),
       id: String(lec.id ?? ''),
       title: lec.title ?? '',
-      duration: lec.totalDurationSeconds ?? 0,
+      duration: lec.duration ?? 0,
       videoUrl: lec.videoUrl ?? '',
       isPreview: !!lec.isPreview,
-      resource: Array.isArray(lec.resource) ? lec.resource : lec.resource ? [lec.resource] : [],
-      _dirty: false,
-      _deleted: false,
+      resource: Array.isArray(lec.resource) ? lec.resource : [],
+      file: lec.file,
+      _dirty: !!lec._dirty,
+      _deleted: !!lec._deleted,
     })),
   }));
 
-  return { courseDraft, sectionDrafts };
+  return { courseDraft: newCourseDraft, sectionDrafts: newSectionDrafts };
 };

--- a/src/mocks/learn.mock.ts
+++ b/src/mocks/learn.mock.ts
@@ -98,7 +98,7 @@ export const MOCK_LEARN_PROGRESS: GetProgressResponse = {
   overallProgressRate: 25,
   lastWatchedResourceId: 3001,
   lastWatchedAt: '2025-12-02T09:30:00',
-  lectureProgresses: [
+  resourceProgresses: [
     {
       resourceId: 3001,
       title: 'JPA란?',

--- a/src/mocks/user.mock.ts
+++ b/src/mocks/user.mock.ts
@@ -9,5 +9,6 @@ export const MOCK_USER: User = {
   enrolledCourses: [],
   createdCourses: [],
   createdAt: new Date('2026-01-01T09:00:00Z'),
+  updatedAt: new Date('2026-01-10T12:00:00Z'),
   instructorApplicationStatus: 'APPROVED',
 };


### PR DESCRIPTION
## 변경 사항

- User / GetProgressResponse / Draft 타입 변경 사항 반영
  - `data` props 타입을 `CourseFormState`, `GetDraftCourseResponse`로 매칭해
    `createCourseFormData` / `mapResponseToCourseDraft` 내부 로직 수정
- 강좌 생성 Draft 매핑 및 시청 종료 progress 저장 호출부 스펙 정합성 맞춤
  - `saveFinalProgressOnEnd` 호출 인자 수정
- 유저/시청 목업 데이터 수정

## 리뷰 필요

- 이 변경으로 인해 **강좌 생성 플로우**(Draft 불러오기/초기값/임시저장→최종등록)가 정상 동작하는지 확인 부탁드립니다.
- **강좌 시청 페이지**에서 종료 시 progress 저장이 정상 동작하는지(종료/탭 이동/뒤로가기 등 주요 케이스) 확인 부탁드립니다.

close #228
