### PR TITLE
refactor: 학습 진도 도메인 로직 개선 (progress=max, resume=recent)

### DIFF
--- a/src/domains/course/hooks/useCourseLearn.ts
+++ b/src/domains/course/hooks/useCourseLearn.ts
@@ -25,6 +25,7 @@ export function useCourseLearn() {
     lectureProgressMap,
     autoSaveProgress,
     saveFinalProgressOnEnd,
+    resetSaveState,
     lastSavedResourceId,
   } = useProgress(courseId);
 
@@ -195,6 +196,7 @@ export function useCourseLearn() {
     lectureProgressMap,
     autoSaveProgress,
     saveFinalProgressOnEnd,
+    resetSaveState,
     totalLectures,
     completedLectures,
   };

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -91,7 +91,7 @@ export function useProgress(courseId: string) {
   const pendingRef = useRef<PendingProgress | null>(null); // 저장 실패 시 재시도 대상
 
   const THROTTLE_INTERVAL = 10_000; // 저장 최소 호출 간격 (ms)
-  const MIN_SAVE_DELTA = 5; // 저장할 최소 재생 시간 변화량 (초)
+  const MIN_SAVE_DELTA = 3; // 저장할 최소 재생 시간 변화량 (초)
   const RETRY_DELAYS = [2000, 5000, 15000]; // 저장 실패 시 재시도 간격 (ms)
 
   // 저장 실패한 진도를 재시도

--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -91,7 +91,7 @@ export function useProgress(courseId: string) {
   const pendingRef = useRef<PendingProgress | null>(null); // 저장 실패 시 재시도 대상
 
   const THROTTLE_INTERVAL = 10_000; // 저장 최소 호출 간격 (ms)
-  const MIN_SAVE_DELTA = 3; // 저장할 최소 재생 시간 변화량 (초)
+  const MIN_SAVE_DELTA = 5; // 저장할 최소 재생 시간 변화량 (초)
   const RETRY_DELAYS = [2000, 5000, 15000]; // 저장 실패 시 재시도 간격 (ms)
 
   // 저장 실패한 진도를 재시도
@@ -135,7 +135,8 @@ export function useProgress(courseId: string) {
       });
     }
 
-    lastSavedDurationRef.current = watchedDuration;
+    lastSavedDurationRef.current = Math.max(lastSavedDurationRef.current, watchedDuration);
+    setLastSavedResourceId(resourceId);
 
     setProgressData((prev) =>
       prev ? applyProgressUpdate(prev, resourceId, watchedDuration) : prev,
@@ -147,19 +148,33 @@ export function useProgress(courseId: string) {
     const now = Date.now();
 
     if (now - lastSavedAtRef.current < THROTTLE_INTERVAL) return;
-    if (Math.abs(watchedDuration - lastSavedDurationRef.current) < MIN_SAVE_DELTA) return;
+    if (watchedDuration - lastSavedDurationRef.current < MIN_SAVE_DELTA) return;
 
     lastSavedAtRef.current = now;
     saveProgress(resourceId, watchedDuration);
   };
 
   // 영상 종료 시 최종 진도 저장
-  const saveFinalProgressOnEnd = (resourceId: number) => {
-    const target = progressData?.resourceProgresses.find((p) => p.resourceId === resourceId);
+  const saveFinalProgressOnEnd = async (resourceId: number) => {
+    if (!progressData) return;
 
+    const target = progressData.resourceProgresses.find((p) => p.resourceId === resourceId);
     if (!target) return;
 
-    saveProgress(resourceId, target.totalDurationSeconds);
+    if (!USE_MOCK) {
+      await updateLearnProgress(courseId, {
+        resourceId,
+        watchedDuration: target.totalDurationSeconds,
+      });
+    }
+
+    setProgressData((prev) =>
+      prev
+        ? applyProgressUpdate(prev, resourceId, target.totalDurationSeconds, {
+            updateLastWatched: false,
+          })
+        : prev,
+    );
   };
 
   // 프론트에서 진도 상태를 계산/반영
@@ -167,25 +182,27 @@ export function useProgress(courseId: string) {
     prev: GetProgressResponse,
     resourceId: number,
     watchedDuration: number,
+    options?: { updateLastWatched?: boolean },
   ): GetProgressResponse {
     const lectureProgresses = (prev.resourceProgresses ?? []).map((p) => {
       if (p.resourceId !== resourceId) return p;
 
+      const safeDuration = Math.max(p.watchedDuration, watchedDuration);
+
       const progressRate =
-        watchedDuration >= p.totalDurationSeconds - 0.5
+        safeDuration >= p.totalDurationSeconds - 0.5
           ? 100
-          : Math.min(100, Math.round((watchedDuration / p.totalDurationSeconds) * 100));
+          : Math.min(100, Math.round((safeDuration / p.totalDurationSeconds) * 100));
 
       return {
         ...p,
-        watchedDuration,
+        watchedDuration: safeDuration,
         progressRate,
         completed: progressRate >= 100,
         lastWatchedAt: new Date().toISOString(),
       };
     });
 
-    // 전체 진도율 재계산
     const overallProgressRate =
       lectureProgresses.length === 0
         ? 0
@@ -194,14 +211,23 @@ export function useProgress(courseId: string) {
               lectureProgresses.length,
           );
 
+    const shouldUpdateLastWatched = options?.updateLastWatched !== false;
+
     return {
       ...prev,
       resourceProgresses: lectureProgresses,
       overallProgressRate,
-      lastWatchedResourceId: resourceId,
-      lastWatchedAt: new Date().toISOString(),
+
+      lastWatchedResourceId: shouldUpdateLastWatched ? resourceId : prev.lastWatchedResourceId,
+
+      lastWatchedAt: shouldUpdateLastWatched ? new Date().toISOString() : prev.lastWatchedAt,
     };
   }
+
+  const resetSaveState = () => {
+    lastSavedDurationRef.current = 0;
+    lastSavedAtRef.current = 0;
+  };
 
   return {
     progress,
@@ -211,6 +237,7 @@ export function useProgress(courseId: string) {
     saveProgress,
     autoSaveProgress,
     saveFinalProgressOnEnd,
+    resetSaveState,
     lastSavedResourceId,
     isLoading,
     error,

--- a/src/domains/course/pages/CourseLearnClientPage.tsx
+++ b/src/domains/course/pages/CourseLearnClientPage.tsx
@@ -16,6 +16,7 @@ import { useCourseLearn } from '@/domains/course/hooks/useCourseLearn';
 import styles from '@/app/courses/[id]/learn/CourseLearnPage.module.css';
 import { formatLectureDuration } from '@/domains/course/utils/formatDuration';
 import { toPublicAssetUrl } from '@/domains/course/utils/toPublicAssetUrl';
+import { useProgress } from '../hooks/useProgress';
 
 export default function CourseLearnClient() {
   const router = useRouter();
@@ -32,6 +33,7 @@ export default function CourseLearnClient() {
     lectureProgressMap,
     autoSaveProgress,
     saveFinalProgressOnEnd,
+    resetSaveState,
     totalLectures,
     completedLectures,
   } = useCourseLearn();
@@ -39,6 +41,7 @@ export default function CourseLearnClient() {
   useEffect(() => {
     if (!currentLecture) return;
     hasSeekedRef.current = false;
+    resetSaveState();
   }, [currentLecture?.resourceId]);
 
   useEffect(() => {


### PR DESCRIPTION
## 변경 사항

- 학습 진도 저장 시 watchedDuration을 max 기준으로 유지하도록 수정
- 되감기 시 진행률이 감소하던 문제 해결
- autoSave 로직에서 5초 이상 유의미한 진행 시에만 저장하도록 개선
- 영상 종료 시 진행률은 100%로 반영하되, 이어보기 기준(lastWatchedResourceId)은 변경되지 않도록 분리
- 이어보기(resume)는 최근 유의미하게 시청한 강의를 기준으로 동작하도록 도메인 로직 정리
- updateLearnProgress 서버 호출과 로컬 상태 반영 로직의 정합성 개선
- 강의 전환 시 delta 계산 오류 방지를 위한 저장 상태 초기화(reset) 로직 추가

## 리뷰 필요

- 진행률(progress=max)과 이어보기(resume=recent) 분리 설계 방향이 적절한지 확인 요청
- 영상 종료 시 이어보기 기준을 유지하는 UX가 의도에 맞는지 확인 요청
- autoSave 저장 조건(5초 이상 진행, 10초 throttle)이 적절한지 검토 요청
- 서버 호출 시점(종료/주기 저장)과 프론트 낙관적 업데이트 구조에 대한 검토 요청


close #234 
