### PR TITLE
refactor: 학습 진도 저장 로직 개선 및 수강 목록 쌓이는 순서 수정

### DIFF
--- a/src/domains/course/hooks/useProgress.ts
+++ b/src/domains/course/hooks/useProgress.ts
@@ -128,19 +128,24 @@ export function useProgress(courseId: string) {
 
   // 진도 즉시 저장
   const saveProgress = async (resourceId: number, watchedDuration: number) => {
+    const prevWatched =
+      progressData?.resourceProgresses.find((p) => p.resourceId === resourceId)?.watchedDuration ??
+      0;
+
+    const safeToSend = Math.max(prevWatched, watchedDuration);
+
     if (!USE_MOCK) {
       await updateLearnProgress(courseId, {
         resourceId,
-        watchedDuration,
+        watchedDuration: safeToSend,
       });
     }
 
-    lastSavedDurationRef.current = Math.max(lastSavedDurationRef.current, watchedDuration);
+    lastSavedDurationRef.current = Math.max(lastSavedDurationRef.current, safeToSend);
+
     setLastSavedResourceId(resourceId);
 
-    setProgressData((prev) =>
-      prev ? applyProgressUpdate(prev, resourceId, watchedDuration) : prev,
-    );
+    setProgressData((prev) => (prev ? applyProgressUpdate(prev, resourceId, safeToSend) : prev));
   };
 
   // 재생 중 주기적 진도 저장

--- a/src/domains/user/pages/EnrollmentClientPage.tsx
+++ b/src/domains/user/pages/EnrollmentClientPage.tsx
@@ -94,7 +94,8 @@ export default function EnrollmentClientPage() {
             return { ...it, isReviewed: hasMine };
           });
 
-          setItems([...merged].reverse());
+          setItems(merged);
+
           return;
         }
 
@@ -108,7 +109,7 @@ export default function EnrollmentClientPage() {
           isReviewed: reviewedMap.get(String(it.courseId)) ?? false,
         }));
 
-        setItems([...merged].reverse());
+        setItems(merged);
       } catch (e) {
         console.error('수강 목록 조회 실패:', e);
       } finally {


### PR DESCRIPTION
## 변경 사항

- 학습 진도 저장 로직 개선
  - watchedDuration을 max 기준(safeDuration)으로 서버/로컬에 동기화하도록 수정
  - setProgressData 중복 호출 제거
  - 영상 종료 시 updateLastWatched 옵션 분리 처리 (이어보기 위치 유지)

- 수강 목록 쌓이는 순서 수정
  - setItems 병합 방식 변경
  - 최초 로딩 시 단일 세팅(setItems(merged))으로 정리
  - 의도한 순서대로 목록이 노출되도록 방향 수정

## 리뷰 필요


- 학습 진도 도메인 로직 (progress=max, resume=recent) 구조가 의도에 맞는지 확인 부탁드립니다.
- 영상 종료 시 lastWatched 갱신을 막은 처리 방식이 UX적으로 적절한지 검토 부탁드립니다.
- 수강 목록 정렬 방향이 서버 응답 기준과 충돌 없는지 확인 부탁드립니다.

close #236 
